### PR TITLE
Rib 74 unify html titles for each page

### DIFF
--- a/src/main/resources/templates/error/page.html
+++ b/src/main/resources/templates/error/page.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+
 <head>
     <meta charset="UTF-8">
-    <title>Rate-It: 404 Not Found</title>
+    <title>404 Not Found | RateSpot</title>
 </head>
+
 <body>
     <h1 th:text="${message}"></h1>
 </body>

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -8,6 +8,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://releases.transloadit.com/uppy/v3.20.0/uppy.min.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" th:href="@{/styles/index.css}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/main/resources/templates/interest/form.html
+++ b/src/main/resources/templates/interest/form.html
@@ -1,18 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title th:if="${interest.id == null}" th:text="'New Interest | RateSpot'"></title>
-    <title th:unless="${interest.id == null}" th:text="${interest.name} + ' Edit Mode | RateSpot '"></title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link rel="stylesheet" type="text/css" th:href="@{/styles/index.css}">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Andika:wght@400;700&family=Montserrat:wght@200;400;600&family=Righteous&family=Ubuntu:wght@400;500;700&display=swap"
-          rel="stylesheet">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="~{fragments.html :: head(title=${interest.id == null} ? 'New Interest' : 'Edit ' + ${interest.name})}">
 </head>
+
 <body>
 <div class="container-fluid">
     <header class="header">

--- a/src/main/resources/templates/interest/form.html
+++ b/src/main/resources/templates/interest/form.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<<<<<<< HEAD
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 
 <head th:replace="~{fragments.html :: head(title=${interest.id == null} ? 'New Interest' : 'Editing ' + ${interest.name})}">

--- a/src/main/resources/templates/interest/invite.html
+++ b/src/main/resources/templates/interest/invite.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>RateSpot: Invite Users</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link rel="stylesheet" type="text/css" th:href="@{/styles/index.css}">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Andika:wght@400;700&family=Montserrat:wght@200;400;600&family=Righteous&family=Ubuntu:wght@400;500;700&display=swap"
-          rel="stylesheet">
+
+<head th:replace="~{fragments.html :: head(title='Applications | ' + ${interest.name})}">
 </head>
+
 <body>
 <div class="container-fluid">
     <header class="header">

--- a/src/main/resources/templates/interest/page.html
+++ b/src/main/resources/templates/interest/page.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+
 <head th:replace="~{fragments.html :: head(title=${interest.name})}">
 </head>
 

--- a/src/main/resources/templates/interest/seeAll.html
+++ b/src/main/resources/templates/interest/seeAll.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>My interests</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link rel="stylesheet" type="text/css" th:href="@{/styles/index.css}">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Andika:wght@400;700&family=Montserrat:wght@200;400;600&family=Righteous&family=Ubuntu:wght@400;500;700&display=swap"
-          rel="stylesheet">
+
+<head th:replace="~{fragments.html :: head(title='My Interests')}">
 </head>
+
 <body>
 <div class="container-fluid">
     <header class="header">

--- a/src/main/resources/templates/interest/users.html
+++ b/src/main/resources/templates/interest/users.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>RateSpot: Manage Users</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link rel="stylesheet" type="text/css" th:href="@{/styles/index.css}">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Andika:wght@400;700&family=Montserrat:wght@200;400;600&family=Righteous&family=Ubuntu:wght@400;500;700&display=swap"
-          rel="stylesheet">
+
+<head th:replace="~{fragments.html :: head(title='Users | ' + ${interest.name})}">
 </head>
+
 <body>
 <div class="container-fluid">
     <header class="header">

--- a/src/main/resources/templates/main/index.html
+++ b/src/main/resources/templates/main/index.html
@@ -1,18 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>RateSpot</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" type="text/css" th:href="@{/styles/index.css}">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Andika:wght@400;700&family=Montserrat:wght@200;400;600&family=Righteous&family=Ubuntu:wght@400;500;700&display=swap"
-          rel="stylesheet">
+
+<head th:replace="~{fragments.html :: head(title='Main Page')}">
 </head>
+
 <body>
 <div class="container-fluid">
     <header class="header">

--- a/src/main/resources/templates/place/form.html
+++ b/src/main/resources/templates/place/form.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<<<<<<< HEAD
 
 <head th:replace="~{fragments.html :: head(title=${place.id == null} ? 'New Place' : 'Editing ' + ${place.name})}">
 </head>

--- a/src/main/resources/templates/place/form.html
+++ b/src/main/resources/templates/place/form.html
@@ -1,18 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title th:if="${place.id == null}" th:text="'New Place | RatePlace'"></title>
-    <title th:unless="${place.id == null}" th:text="${place.name} + ' Edit Mode | RatePlace'"></title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link rel="stylesheet" type="text/css" th:href="@{/styles/index.css}">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Andika:wght@400;700&family=Montserrat:wght@200;400;600&family=Righteous&family=Ubuntu:wght@400;500;700&display=swap"
-          rel="stylesheet">
+
+<head th:replace="~{fragments.html :: head(title=${place.id == null} ? 'New Place' : 'Edit ' + ${place.name})}">
 </head>
+
 <body>
 <div class="container-fluid">
     <header class="header">

--- a/src/main/resources/templates/place/page.html
+++ b/src/main/resources/templates/place/page.html
@@ -9,7 +9,7 @@
     <header class="header">
         <div th:replace="~{fragments.html :: hamburger-menu}"></div>
         <div th:replace="~{fragments.html :: logo}"></div>
-        <div th:replace="${loggedUser != null && loggedUser.getCreatedPlaces().contains(place)} ?
+        <div th:replace="${loggedUser != null && place.creator.equals(loggedUser)} ?
          ~{fragments.html :: place-admin-menu} : ~{fragments.html :: login-menu}"></div>
         <script th:replace="~{fragments.html :: topbar-script}"></script>
     </header>

--- a/src/main/resources/templates/place/page.html
+++ b/src/main/resources/templates/place/page.html
@@ -1,19 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title th:text="${place.name} + ' | RateSpot'">RateSpot</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link href="https://releases.transloadit.com/uppy/v3.20.0/uppy.min.css" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" th:href="@{/styles/index.css}">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Andika:wght@400;700&family=Montserrat:wght@200;400;600&family=Righteous&family=Ubuntu:wght@400;500;700&display=swap"
-          rel="stylesheet">
+<head th:replace="~{fragments.html :: head(title=${place.name})}">
 </head>
 
 <body th:object="${place}">


### PR DESCRIPTION
### RIB-74: Unify html titles

- unifying html titles on all pages except login and logout as those are currently being worked on
- all pages are now using the same head fragment