### PR TITLE
RIB-96: added docker file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.20.0'
     implementation 'com.google.api-client:google-api-client:1.29.2'
     implementation 'org.springframework.boot:spring-boot-starter-mail:3.1.2'
+    implementation 'org.postgresql:postgresql:42.6.0'
 }
 
 tasks.named('test') {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+
+  crdb:
+    container_name: crdb
+    hostname: crdb
+    image: cockroachdb/cockroach:latest
+    command: start-single-node --cluster-name=example-single-node --logtostderr=WARNING --log-file-verbosity=WARNING --insecure
+    ports:
+      - "26257:26257"
+      - "8888:8080"
+    volumes:
+      - roach-single:/cockroach/cockroach-data
+
+volumes:
+  roach-single:

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,4 +1,12 @@
-spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.url=jdbc:postgresql://localhost:26257/defaultdb
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.username=root
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+# set this to true to automatically create data into the database
+app.preload-data=false
+
 spring.flyway.enabled=false
 spring.mvc.hiddenmethod.filter.enabled=true
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,6 +1,6 @@
 spring.datasource.url=jdbc:h2:mem:inttestdb
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-
+spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.hibernate.ddl-auto=create-drop
 
 spring.flyway.enabled=false


### PR DESCRIPTION
After this change is merged, the default dev database will not be h2 anymore. This means all data will be persisted.

To run the database, download docker: https://docs.docker.com/desktop/install/windows-install/

In the command line: 
Navigate to folder "docker" in this repository - `cd docker`
run `docker compose up`

After this, you should be able to use the database. 