### PR TITLE
RIB-129 refactor create edit interest to include categories selection

### DIFF
--- a/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
@@ -2,6 +2,7 @@ package it.rate.webapp.controllers;
 
 import it.rate.webapp.exceptions.badrequest.BadRequestException;
 import it.rate.webapp.models.AppUser;
+import it.rate.webapp.models.Category;
 import it.rate.webapp.models.Interest;
 import it.rate.webapp.models.Role;
 import it.rate.webapp.services.*;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.security.Principal;
+import java.util.List;
 import java.util.Set;
 
 @Controller
@@ -24,16 +26,19 @@ public class InterestAdminController {
   private final RoleService roleService;
   private final UserService userService;
   private final CriterionService criterionService;
+  private final CategoryService categoryService;
 
   @GetMapping("/edit")
   @PreAuthorize("@permissionService.manageCommunity(#interestId)")
   public String editInterestPage(@PathVariable Long interestId, Model model, Principal principal) {
 
-    model.addAttribute("interest", interestService.getById(interestId));
+    Interest interest = interestService.getById(interestId);
+    model.addAttribute("interest", interest);
     model.addAttribute("action", "/interests/" + interestId + "/admin/edit");
     model.addAttribute("method", "put");
     model.addAttribute("loggedUser", userService.getByEmail(principal.getName()));
-
+    model.addAttribute("allCategories", categoryService.findAll());
+    model.addAttribute("selectedCategories", interest.getCategories());
     return "interest/form";
   }
 

--- a/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
@@ -32,8 +32,7 @@ public class InterestAdminController {
   @PreAuthorize("@permissionService.manageCommunity(#interestId)")
   public String editInterestPage(@PathVariable Long interestId, Model model, Principal principal) {
 
-    Interest interest = interestService.getById(interestId);
-    model.addAttribute("interest", interest);
+    model.addAttribute("interest", interestService.getById(interestId));
     model.addAttribute("action", "/interests/" + interestId + "/admin/edit");
     model.addAttribute("method", "put");
     model.addAttribute("loggedUser", userService.getByEmail(principal.getName()));

--- a/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
@@ -37,17 +37,22 @@ public class InterestAdminController {
     model.addAttribute("action", "/interests/" + interestId + "/admin/edit");
     model.addAttribute("method", "put");
     model.addAttribute("loggedUser", userService.getByEmail(principal.getName()));
-    model.addAttribute("allCategories", categoryService.findAll());
-    model.addAttribute("selectedCategories", interest.getCategories());
+    model.addAttribute("categories", categoryService.findAll());
+    model.addAttribute("maxCategories", categoryService.getMaxCategories());
     return "interest/form";
   }
 
   @PutMapping("/edit")
   @PreAuthorize("@permissionService.manageCommunity(#interestId)")
   public String editInterest(
-      @PathVariable Long interestId, Interest interest, @RequestParam Set<String> criteriaNames) {
+      @PathVariable Long interestId,
+      Interest interest,
+      @RequestParam Set<String> criteriaNames,
+      @RequestParam(required = false) Set<Long> categoryIds) {
 
     interest.setId(interestId);
+    List<Category> categories = categoryService.findMaxLimitByIdIn(categoryIds);
+    interest.setCategories(categories);
     criterionService.updateExisting(interestService.save(interest), criteriaNames);
 
     return String.format("redirect:/interests/%d", interestId);

--- a/src/main/java/it/rate/webapp/controllers/InterestController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestController.java
@@ -52,7 +52,7 @@ public class InterestController {
       Principal principal) {
 
     AppUser loggedUser = userService.getByEmail(principal.getName());
-    List<Category> categories = categoryService.findAllByIdIn(categoryIds);
+    List<Category> categories = categoryService.findMaxLimitByIdIn(categoryIds);
     interest.setCategories(categories);
     Interest savedInterest = interestService.save(interest);
     criterionService.createNew(savedInterest, criteriaNames);

--- a/src/main/java/it/rate/webapp/repositories/CategoryRepository.java
+++ b/src/main/java/it/rate/webapp/repositories/CategoryRepository.java
@@ -3,4 +3,10 @@ package it.rate.webapp.repositories;
 import it.rate.webapp.models.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CategoryRepository extends JpaRepository<Category, Long> {}
+import java.util.List;
+import java.util.Set;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    public List<Category> findAllByIdIn(Set<Long> ids);
+}

--- a/src/main/java/it/rate/webapp/repositories/CategoryRepository.java
+++ b/src/main/java/it/rate/webapp/repositories/CategoryRepository.java
@@ -8,5 +8,5 @@ import java.util.Set;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    public List<Category> findAllByIdIn(Set<Long> ids);
+  public List<Category> findAllByIdIn(Set<Long> ids);
 }

--- a/src/main/java/it/rate/webapp/services/CategoryService.java
+++ b/src/main/java/it/rate/webapp/services/CategoryService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 @Service
@@ -26,7 +25,11 @@ public class CategoryService {
     return this.MAX_CATEGORIES_PER_INTEREST;
   }
 
-  public List<Category> findAllByIdIn(@Size(max = MAX_CATEGORIES_PER_INTEREST) Set<Long> ids) {
+  public List<Category> findAllByIdIn(Set<Long> ids) {
     return categoryRepository.findAllByIdIn(ids);
+  }
+
+  public List<Category> findMaxLimitByIdIn(@Size(max = MAX_CATEGORIES_PER_INTEREST) Set<Long> ids) {
+    return findAllByIdIn(ids);
   }
 }

--- a/src/main/java/it/rate/webapp/services/CategoryService.java
+++ b/src/main/java/it/rate/webapp/services/CategoryService.java
@@ -2,17 +2,31 @@ package it.rate.webapp.services;
 
 import it.rate.webapp.models.Category;
 import it.rate.webapp.repositories.CategoryRepository;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Service
+@Validated
 @AllArgsConstructor
 public class CategoryService {
   private final CategoryRepository categoryRepository;
+  private final int MAX_CATEGORIES_PER_INTEREST = 3;
 
   public List<Category> findAll() {
     return categoryRepository.findAll();
+  }
+
+  public int getMaxCategories() {
+    return this.MAX_CATEGORIES_PER_INTEREST;
+  }
+
+  public List<Category> findAllByIdIn(@Size(max = MAX_CATEGORIES_PER_INTEREST) Set<Long> ids) {
+    return categoryRepository.findAllByIdIn(ids);
   }
 }

--- a/src/main/resources/static/scripts/categorySplide.js
+++ b/src/main/resources/static/scripts/categorySplide.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const categorySplide = new Splide('#splide-category', {
+        autoWidth: true,
+        autoHeight: true,
+        gap: '0.5rem',
+        type: 'slide',
+        drag: 'free',
+        arrows: false,
+        loop: false,
+        pagination: false
+    });
+    categorySplide.mount();
+});

--- a/src/main/resources/static/scripts/indexSplide.js
+++ b/src/main/resources/static/scripts/indexSplide.js
@@ -10,16 +10,4 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     splide.mount();
     loadInterests();
-
-    const categorySplide = new Splide('#splide-category', {
-        autoWidth: true,
-        autoHeight: true,
-        gap: '0.5rem',
-        type: 'slide',
-        drag: 'free',
-        arrows: false,
-        loop: false,
-        pagination: false
-    });
-    categorySplide.mount();
 });

--- a/src/main/resources/static/scripts/interestForm.js
+++ b/src/main/resources/static/scripts/interestForm.js
@@ -70,22 +70,28 @@ document.addEventListener('DOMContentLoaded', function () {
         };
     });
 
+    disableCategoryIfMax();
+
     const categoryBoxes = document.querySelectorAll(".sort-checkbox");
     categoryBoxes.forEach(checkbox => {
         checkbox.addEventListener('change', function () {
-            const checkedBoxes = document.querySelectorAll(".sort-checkbox:checked");
-            const uncheckedBoxes = document.querySelectorAll(".sort-checkbox:not(:checked)");
-
-            if (checkedBoxes.length >= MAX_CATEGORIES) {
-                uncheckedBoxes.forEach(checkbox => {
-                    checkbox.disabled = true;
-                });
-            } else {
-                uncheckedBoxes.forEach(checkbox => {
-                    checkbox.disabled = false;
-                });
-            }
+            disableCategoryIfMax();
         })
     })
-
 });
+
+
+function disableCategoryIfMax() {
+    const checkedBoxes = document.querySelectorAll(".sort-checkbox:checked");
+    const uncheckedBoxes = document.querySelectorAll(".sort-checkbox:not(:checked)");
+
+    if (checkedBoxes.length >= MAX_CATEGORIES) {
+        uncheckedBoxes.forEach(checkbox => {
+            checkbox.disabled = true;
+        });
+    } else {
+        uncheckedBoxes.forEach(checkbox => {
+            checkbox.disabled = false;
+        });
+    }
+}

--- a/src/main/resources/static/scripts/interestForm.js
+++ b/src/main/resources/static/scripts/interestForm.js
@@ -69,4 +69,23 @@ document.addEventListener('DOMContentLoaded', function () {
             removeCriteria(null, button.closest('div'));
         };
     });
+
+    const categoryBoxes = document.querySelectorAll(".sort-checkbox");
+    categoryBoxes.forEach(checkbox => {
+        checkbox.addEventListener('change', function () {
+            const checkedBoxes = document.querySelectorAll(".sort-checkbox:checked");
+            const uncheckedBoxes = document.querySelectorAll(".sort-checkbox:not(:checked)");
+
+            if (checkedBoxes.length >= MAX_CATEGORIES) {
+                uncheckedBoxes.forEach(checkbox => {
+                    checkbox.disabled = true;
+                });
+            } else {
+                uncheckedBoxes.forEach(checkbox => {
+                    checkbox.disabled = false;
+                });
+            }
+        })
+    })
+
 });

--- a/src/main/resources/static/styles/index.css
+++ b/src/main/resources/static/styles/index.css
@@ -479,6 +479,10 @@ h3 {
     display: flex;
 }
 
+.sort-container:hover {
+    cursor: pointer;
+}
+
 .sort-container > .sort-checkbox + span {
     padding: 0.3em 0.5em;
     text-align: justify;

--- a/src/main/resources/templates/interest/form.html
+++ b/src/main/resources/templates/interest/form.html
@@ -27,7 +27,12 @@
 
             <section class="input-param">
                 <h4>Category</h4>
-                <p>TBD</p>
+                <div class="sort-buttons">
+                    <label class="sort-container" th:each="category : ${categories}">
+                        <input type="checkbox" name="categoryIds" th:value="${category.id}" class="sort-checkbox"/>
+                        <span th:text="${category.name}"></span>
+                    </label>
+                </div>
             </section>
 
             <section class="input-param">
@@ -55,7 +60,8 @@
                             <label class="list-record">
                                 <input class="input-text-field" type="text" name="criteriaNames"
                                        th:value="${criterion.name}" required/>
-                                <button class="role-option-button kick-button" type="button" onclick="removeCriteria(this, ${iterStat.index})">
+                                <button class="role-option-button kick-button" type="button"
+                                        onclick="removeCriteria(this, ${iterStat.index})">
                                     <img src="/icons/cross.svg" alt="Kick">
                                 </button>
                             </label>
@@ -88,14 +94,17 @@
                 <button class="button" type="submit">Save</button>
             </div>
 
-            <input type="hidden" id="uploadedImageId" name="uploadedImageId" th:field="*{imageName}" />
+            <input type="hidden" id="uploadedImageId" name="uploadedImageId" th:field="*{imageName}"/>
 
         </form>
     </div>
 </div>
 
-    <script type="module" src="/scripts/interestImageUpload.js"></script>
-    <script src="/scripts/interestForm.js"></script>
+<script type="module" src="/scripts/interestImageUpload.js"></script>
+<script src="/scripts/interestForm.js"></script>
+<script th:inline="javascript">
+    const MAX_CATEGORIES = [[${maxCategories}]];
+</script>
 
 </body>
 </html>

--- a/src/main/resources/templates/interest/form.html
+++ b/src/main/resources/templates/interest/form.html
@@ -29,7 +29,7 @@
                 <h4>Category</h4>
                 <div class="sort-buttons">
                     <label class="sort-container" th:each="category : ${categories}">
-                        <input type="checkbox" name="categoryIds" th:value="${category.id}" class="sort-checkbox"/>
+                        <input th:checked="${interest.categoryIds.contains(category.id)}" type="checkbox" name="categoryIds" th:value="${category.id}" class="sort-checkbox"/>
                         <span th:text="${category.name}"></span>
                     </label>
                 </div>

--- a/src/main/resources/templates/main/index.html
+++ b/src/main/resources/templates/main/index.html
@@ -55,23 +55,19 @@
                 <a th:if="${loggedUser}" th:href="@{/interests/create}"><h3>Create new</h3></a>
             </div>
 
-<!--            <div class="sort-buttons">-->
-                <section class="splide" id="splide-category" aria-label="Categories">
-                    <div class="splide__track">
-                        <div class="splide__list">
-                            <div class="splide__slide" th:each="category : ${categories}">
-
-                                <label class="sort-container">
-                                    <input th:value="${category.id}" oninput="filterInterests(this)" type="checkbox"
-                                           class="sort-checkbox"/>
-                                    <span th:text="${category.name}"></span>
-                                </label>
-
-                            </div>
+            <section class="splide" id="splide-category" aria-label="Categories">
+                <div class="splide__track">
+                    <div class="splide__list">
+                        <div class="splide__slide" th:each="category : ${categories}">
+                            <label class="sort-container">
+                                <input th:value="${category.id}" oninput="filterInterests(this)" type="checkbox"
+                                       class="sort-checkbox"/>
+                                <span th:text="${category.name}"></span>
+                            </label>
                         </div>
                     </div>
-                </section>
-<!--            </div>-->
+                </div>
+            </section>
 
             <div class="search-container">
                 <input type="text" class="search" name="query" oninput="filterInterests()" autocomplete="off"
@@ -96,6 +92,7 @@
 </div>
 <script src="/scripts/imageFetcher.js"></script>
 <script src="/scripts/index.js"></script>
+<script src="/scripts/categorySplide.js"></script>
 <script th:unless="${likedInterests == null || likedInterests.isEmpty()}" src="/scripts/indexSplide.js"></script>
 </body>
 </html>

--- a/src/test/java/it/rate/webapp/services/CategoryServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/CategoryServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -21,10 +22,12 @@ class CategoryServiceTest extends BaseTest {
 
   @Test
   void findMaxLimitByIdIn_TooManyCategoriesThrowsException() {
-    when(categoryRepository.findAllByIdIn(any()))
-        .thenReturn(
-            List.of(new Category("Test 1"), new Category("Test 2"), new Category("Test 3")));
-    Set<Long> categoryIds = Set.of(1L, 2L, 3L, 4L);
+    int maxLimit = categoryService.getMaxCategories();
+    Set<Long> categoryIds = new HashSet<>();
+    for (int i = 0; i < maxLimit + 1; i++) {
+      categoryIds.add((long) i + 1);
+    }
+    when(categoryRepository.findAllByIdIn(any())).thenReturn(List.of(new Category()));
 
     assertThrows(
         ConstraintViolationException.class, () -> categoryService.findMaxLimitByIdIn(categoryIds));

--- a/src/test/java/it/rate/webapp/services/CategoryServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/CategoryServiceTest.java
@@ -1,0 +1,32 @@
+package it.rate.webapp.services;
+
+import it.rate.webapp.BaseTest;
+import it.rate.webapp.models.Category;
+import it.rate.webapp.repositories.CategoryRepository;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class CategoryServiceTest extends BaseTest {
+  @MockBean CategoryRepository categoryRepository;
+  @Autowired CategoryService categoryService;
+
+  @Test
+  void findMaxLimitByIdIn_TooManyCategoriesThrowsException() {
+    when(categoryRepository.findAllByIdIn(any()))
+        .thenReturn(
+            List.of(new Category("Test 1"), new Category("Test 2"), new Category("Test 3")));
+    Set<Long> categoryIds = Set.of(1L, 2L, 3L, 4L);
+
+    assertThrows(
+        ConstraintViolationException.class, () -> categoryService.findMaxLimitByIdIn(categoryIds));
+  }
+}


### PR DESCRIPTION
# RIB-129 : Refactor Interest create/edit page to include categories
- Maximum number of allowed categories per interest set in CategoryService as constant
- User able to create Interest and optionally add up to (at the moment) 3 categories
- Same applies when editing interest

- Currently not giving any hints to user as to how many can he select at the time, but attribute is available in the view model to play with. Possibly could be included in the Javascript questionmark hints task we talked about earlier.

![image](https://github.com/MatejFrnka/rate-it/assets/116947425/890ff058-b209-4aa0-aa6f-b722face68e3)
