### PR TITLE
Rib 159 fix database settings for long descriptions

### DIFF
--- a/src/main/java/it/rate/webapp/config/Constraints.java
+++ b/src/main/java/it/rate/webapp/config/Constraints.java
@@ -9,9 +9,7 @@ public class Constraints {
 
   // Description length up to 1000
   public static final int MAX_DESCRIPTION_LENGTH = 1000;
-
-  public static final int MIN_PASSWORD_LENGTH = 8;
-  public static final int MAX_PASSWORD_LENGTH = 255;
+  public static final int MAX_VARCHAR_LENGTH = 255;
   public static final int MIN_USERNAME_LENGTH = 3;
   public static final int MAX_USERNAME_LENGTH = 25;
   public static final String PASSWORD_REGEX = "^(?=.*[A-Z])(?=.*[0-9]).{8,}$";

--- a/src/main/java/it/rate/webapp/config/Constraints.java
+++ b/src/main/java/it/rate/webapp/config/Constraints.java
@@ -13,4 +13,5 @@ public class Constraints {
   public static final int MIN_USERNAME_LENGTH = 3;
   public static final int MAX_USERNAME_LENGTH = 25;
   public static final String PASSWORD_REGEX = "^(?=.*[A-Z])(?=.*[0-9]).{8,}$";
+  public static final int MAX_CATEGORIES_PER_INTEREST = 3;
 }

--- a/src/main/java/it/rate/webapp/config/Constraints.java
+++ b/src/main/java/it/rate/webapp/config/Constraints.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Component;
 public class Constraints {
   public static final int MIN_NAME_LENGTH = 3;
   public static final int MAX_NAME_LENGTH = 25;
-  public static final int MIN_DESCRIPTION_LENGTH = 10;
+
+  // Description length up to 1000
   public static final int MAX_DESCRIPTION_LENGTH = 1000;
+
   public static final int MIN_PASSWORD_LENGTH = 8;
   public static final int MAX_PASSWORD_LENGTH = 255;
   public static final int MIN_USERNAME_LENGTH = 3;

--- a/src/main/java/it/rate/webapp/config/Constraints.java
+++ b/src/main/java/it/rate/webapp/config/Constraints.java
@@ -1,0 +1,16 @@
+package it.rate.webapp.config;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class Constraints {
+  public static final int MIN_NAME_LENGTH = 3;
+  public static final int MAX_NAME_LENGTH = 25;
+  public static final int MIN_DESCRIPTION_LENGTH = 10;
+  public static final int MAX_DESCRIPTION_LENGTH = 1000;
+  public static final int MIN_PASSWORD_LENGTH = 8;
+  public static final int MAX_PASSWORD_LENGTH = 255;
+  public static final int MIN_USERNAME_LENGTH = 3;
+  public static final int MAX_USERNAME_LENGTH = 25;
+  public static final String PASSWORD_REGEX = "^(?=.*[A-Z])(?=.*[0-9]).{8,}$";
+}

--- a/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
@@ -6,6 +6,7 @@ import it.rate.webapp.models.Category;
 import it.rate.webapp.models.Interest;
 import it.rate.webapp.models.Role;
 import it.rate.webapp.services.*;
+import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -37,10 +38,11 @@ public class InterestAdminController {
     model.addAttribute("method", "put");
     model.addAttribute("loggedUser", userService.getByEmail(principal.getName()));
     model.addAttribute("categories", categoryService.findAll());
-    model.addAttribute("maxCategories", categoryService.getMaxCategories());
+
     return "interest/form";
   }
 
+  @Transactional
   @PutMapping("/edit")
   @PreAuthorize("@permissionService.manageCommunity(#interestId)")
   public String editInterest(
@@ -49,10 +51,11 @@ public class InterestAdminController {
       @RequestParam Set<String> criteriaNames,
       @RequestParam(required = false) Set<Long> categoryIds) {
 
-    interest.setId(interestId);
+//    interest.setId(interestId);
     List<Category> categories = categoryService.findMaxLimitByIdIn(categoryIds);
     interest.setCategories(categories);
-    criterionService.updateExisting(interestService.save(interest), criteriaNames);
+    Interest editedInterest = interestService.saveEdited(interest);
+    criterionService.updateExisting(editedInterest, criteriaNames);
 
     return String.format("redirect:/interests/%d", interestId);
   }

--- a/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
@@ -51,7 +51,7 @@ public class InterestAdminController {
       @RequestParam Set<String> criteriaNames,
       @RequestParam(required = false) Set<Long> categoryIds) {
 
-//    interest.setId(interestId);
+    interest.setId(interestId);
     List<Category> categories = categoryService.findMaxLimitByIdIn(categoryIds);
     interest.setCategories(categories);
     Interest editedInterest = interestService.saveEdited(interest);

--- a/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
@@ -54,8 +54,8 @@ public class InterestAdminController {
     interest.setId(interestId);
     List<Category> categories = categoryService.findMaxLimitByIdIn(categoryIds);
     interest.setCategories(categories);
-    Interest editedInterest = interestService.saveEdited(interest);
-    criterionService.updateExisting(editedInterest, criteriaNames);
+    Interest updatedInterest = interestService.update(interest);
+    criterionService.updateExisting(updatedInterest, criteriaNames);
 
     return String.format("redirect:/interests/%d", interestId);
   }

--- a/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestAdminController.java
@@ -1,8 +1,8 @@
 package it.rate.webapp.controllers;
 
+import it.rate.webapp.dtos.InterestInDTO;
 import it.rate.webapp.exceptions.badrequest.BadRequestException;
 import it.rate.webapp.models.AppUser;
-import it.rate.webapp.models.Category;
 import it.rate.webapp.models.Interest;
 import it.rate.webapp.models.Role;
 import it.rate.webapp.services.*;
@@ -15,8 +15,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.security.Principal;
-import java.util.List;
-import java.util.Set;
 
 @Controller
 @AllArgsConstructor
@@ -46,16 +44,12 @@ public class InterestAdminController {
   @PutMapping("/edit")
   @PreAuthorize("@permissionService.manageCommunity(#interestId)")
   public String editInterest(
-      @PathVariable Long interestId,
-      Interest interest,
-      @RequestParam Set<String> criteriaNames,
-      @RequestParam(required = false) Set<Long> categoryIds) {
+          @PathVariable Long interestId,
+          InterestInDTO interestDTO) {
 
-    interest.setId(interestId);
-    List<Category> categories = categoryService.findMaxLimitByIdIn(categoryIds);
-    interest.setCategories(categories);
-    Interest updatedInterest = interestService.update(interest);
-    criterionService.updateExisting(updatedInterest, criteriaNames);
+    Interest interest = interestService.getById(interestId);
+    interest = interestService.update(interest, interestDTO);
+    criterionService.updateAll(interest, interestDTO.criteriaNames());
 
     return String.format("redirect:/interests/%d", interestId);
   }

--- a/src/main/java/it/rate/webapp/controllers/InterestController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestController.java
@@ -39,7 +39,6 @@ public class InterestController {
     model.addAttribute("method", "post");
     model.addAttribute("loggedUser", userService.getByEmail(principal.getName()));
     model.addAttribute("categories", categoryService.findAll());
-    model.addAttribute("maxCategories", categoryService.getMaxCategories());
 
     return "interest/form";
   }
@@ -56,7 +55,7 @@ public class InterestController {
     AppUser loggedUser = userService.getByEmail(principal.getName());
     List<Category> categories = categoryService.findMaxLimitByIdIn(categoryIds);
     interest.setCategories(categories);
-    Interest savedInterest = interestService.save(interest);
+    Interest savedInterest = interestService.saveNew(interest);
     criterionService.createNew(savedInterest, criteriaNames);
     roleService.setRole(savedInterest, loggedUser, Role.RoleType.CREATOR);
     likeService.save(loggedUser, savedInterest);

--- a/src/main/java/it/rate/webapp/controllers/InterestController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestController.java
@@ -49,15 +49,10 @@ public class InterestController {
   @PostMapping("/create")
   public String createInterest(
       InterestInDTO interestDTO,
-      @RequestParam Set<String> criteriaNames,
-      @RequestParam(required = false) Set<Long> categoryIds,
       Principal principal) {
 
-    Interest interest = new Interest(interestDTO);
-    List<Category> categories = categoryService.findMaxLimitByIdIn(categoryIds);
-    interest.setCategories(categories);
-    interest = interestService.save(interest);
-    criterionService.createNew(interest, criteriaNames);
+    Interest interest = interestService.save(interestDTO);
+    criterionService.saveAll(interest, interestDTO.criteriaNames());
     AppUser loggedUser = userService.getByEmail(principal.getName());
     roleService.setRole(interest, loggedUser, Role.RoleType.CREATOR);
     likeService.save(loggedUser, interest);

--- a/src/main/java/it/rate/webapp/controllers/InterestController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestController.java
@@ -53,12 +53,12 @@ public class InterestController {
       @RequestParam(required = false) Set<Long> categoryIds,
       Principal principal) {
 
-    AppUser loggedUser = userService.getByEmail(principal.getName());
-    List<Category> categories = categoryService.findMaxLimitByIdIn(categoryIds);
     Interest interest = new Interest(interestDTO);
+    List<Category> categories = categoryService.findMaxLimitByIdIn(categoryIds);
     interest.setCategories(categories);
     interest = interestService.save(interest);
     criterionService.createNew(interest, criteriaNames);
+    AppUser loggedUser = userService.getByEmail(principal.getName());
     roleService.setRole(interest, loggedUser, Role.RoleType.CREATOR);
     likeService.save(loggedUser, interest);
 

--- a/src/main/java/it/rate/webapp/controllers/InterestController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestController.java
@@ -1,5 +1,6 @@
 package it.rate.webapp.controllers;
 
+import it.rate.webapp.dtos.InterestInDTO;
 import it.rate.webapp.exceptions.badrequest.InvalidInterestDetailsException;
 import it.rate.webapp.exceptions.notfound.InterestNotFoundException;
 import it.rate.webapp.models.*;
@@ -47,20 +48,21 @@ public class InterestController {
   @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
   @PostMapping("/create")
   public String createInterest(
-      Interest interest,
+      InterestInDTO interestDTO,
       @RequestParam Set<String> criteriaNames,
       @RequestParam(required = false) Set<Long> categoryIds,
       Principal principal) {
 
     AppUser loggedUser = userService.getByEmail(principal.getName());
     List<Category> categories = categoryService.findMaxLimitByIdIn(categoryIds);
+    Interest interest = new Interest(interestDTO);
     interest.setCategories(categories);
-    Interest savedInterest = interestService.saveNew(interest);
-    criterionService.createNew(savedInterest, criteriaNames);
-    roleService.setRole(savedInterest, loggedUser, Role.RoleType.CREATOR);
-    likeService.save(loggedUser, savedInterest);
+    interest = interestService.save(interest);
+    criterionService.createNew(interest, criteriaNames);
+    roleService.setRole(interest, loggedUser, Role.RoleType.CREATOR);
+    likeService.save(loggedUser, interest);
 
-    return String.format("redirect:/interests/%d", savedInterest.getId());
+    return String.format("redirect:/interests/%d", interest.getId());
   }
 
   @GetMapping("/{interestId}")

--- a/src/main/java/it/rate/webapp/controllers/InterestController.java
+++ b/src/main/java/it/rate/webapp/controllers/InterestController.java
@@ -7,6 +7,7 @@ import it.rate.webapp.services.*;
 import java.security.Principal;
 import java.util.*;
 
+import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -43,6 +44,7 @@ public class InterestController {
     return "interest/form";
   }
 
+  @Transactional
   @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
   @PostMapping("/create")
   public String createInterest(

--- a/src/main/java/it/rate/webapp/controllers/PlaceController.java
+++ b/src/main/java/it/rate/webapp/controllers/PlaceController.java
@@ -44,12 +44,11 @@ public class PlaceController {
   public String createNewPlace(
       @PathVariable Long interestId, PlaceInDTO placeDTO, Principal principal) {
 
-    Place place = new Place(placeDTO);
-    AppUser loggedUser = userService.getByEmail(principal.getName());
     Interest interest = interestService.getById(interestId);
-    Place createdPlace = placeService.save(place, interest, loggedUser);
+    AppUser loggedUser = userService.getByEmail(principal.getName());
+    Place place = placeService.save(placeDTO, interest, loggedUser);
 
-    return String.format("redirect:/interests/%d/places/%d", interestId, createdPlace.getId());
+    return String.format("redirect:/interests/%d/places/%d", interestId, place.getId());
   }
 
   @GetMapping("/{placeId}")

--- a/src/main/java/it/rate/webapp/controllers/PlaceController.java
+++ b/src/main/java/it/rate/webapp/controllers/PlaceController.java
@@ -1,8 +1,10 @@
 package it.rate.webapp.controllers;
 
+import it.rate.webapp.dtos.PlaceInDTO;
 import it.rate.webapp.exceptions.notfound.PlaceNotFoundException;
 import it.rate.webapp.models.*;
 import it.rate.webapp.services.*;
+import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -36,10 +38,12 @@ public class PlaceController {
     return "place/form";
   }
 
+  @Transactional
   @PostMapping("/new")
   @PreAuthorize("@permissionService.createPlace(#interestId)")
-  public String createNewPlace(@PathVariable Long interestId, Place place, Principal principal) {
+  public String createNewPlace(@PathVariable Long interestId, PlaceInDTO placeDTO, Principal principal) {
 
+    Place place = new Place(placeDTO);
     AppUser loggedUser = userService.getByEmail(principal.getName());
     Interest interest = interestService.getById(interestId);
     Place createdPlace = placeService.save(place, interest, loggedUser);
@@ -83,15 +87,13 @@ public class PlaceController {
     return "place/form";
   }
 
+  @Transactional
   @PutMapping("/{placeId}/edit")
   @PreAuthorize("@permissionService.hasPlaceEditPermissions(#placeId, #interestId)")
   public String editPlace(
-      @PathVariable Long interestId, @PathVariable Long placeId, Place place, Principal principal) {
+      @PathVariable Long interestId, @PathVariable Long placeId, PlaceInDTO placeDTO) {
 
-    place.setId(placeId);
-    Interest interest = interestService.getById(interestId);
-    AppUser loggedUser = userService.getByEmail(principal.getName());
-    placeService.save(place, interest, loggedUser);
+    Place place = placeService.update(placeService.getById(placeId), placeDTO);
 
     return String.format("redirect:/interests/%d/places/%d", interestId, place.getId());
   }

--- a/src/main/java/it/rate/webapp/controllers/PlaceController.java
+++ b/src/main/java/it/rate/webapp/controllers/PlaceController.java
@@ -41,7 +41,8 @@ public class PlaceController {
   @Transactional
   @PostMapping("/new")
   @PreAuthorize("@permissionService.createPlace(#interestId)")
-  public String createNewPlace(@PathVariable Long interestId, PlaceInDTO placeDTO, Principal principal) {
+  public String createNewPlace(
+      @PathVariable Long interestId, PlaceInDTO placeDTO, Principal principal) {
 
     Place place = new Place(placeDTO);
     AppUser loggedUser = userService.getByEmail(principal.getName());

--- a/src/main/java/it/rate/webapp/dtos/InterestInDTO.java
+++ b/src/main/java/it/rate/webapp/dtos/InterestInDTO.java
@@ -1,0 +1,12 @@
+package it.rate.webapp.dtos;
+
+import it.rate.webapp.config.Constraints;
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
+
+public record InterestInDTO(
+    @NotBlank @Length(min = Constraints.MIN_NAME_LENGTH, max = Constraints.MAX_NAME_LENGTH)
+        String name,
+    @NotBlank @Length(max = Constraints.MAX_DESCRIPTION_LENGTH) String description,
+    boolean exclusive,
+    String imageName) {}

--- a/src/main/java/it/rate/webapp/dtos/InterestInDTO.java
+++ b/src/main/java/it/rate/webapp/dtos/InterestInDTO.java
@@ -2,11 +2,16 @@ package it.rate.webapp.dtos;
 
 import it.rate.webapp.config.Constraints;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
+
+import java.util.Set;
 
 public record InterestInDTO(
     @NotBlank @Length(min = Constraints.MIN_NAME_LENGTH, max = Constraints.MAX_NAME_LENGTH)
         String name,
     @NotBlank @Length(max = Constraints.MAX_DESCRIPTION_LENGTH) String description,
+    @NotNull Set<@NotBlank @Length(max = Constraints.MAX_NAME_LENGTH) String> criteriaNames,
+    Set<Long> categoryIds,
     boolean exclusive,
     String imageName) {}

--- a/src/main/java/it/rate/webapp/dtos/PlaceInDTO.java
+++ b/src/main/java/it/rate/webapp/dtos/PlaceInDTO.java
@@ -1,0 +1,15 @@
+package it.rate.webapp.dtos;
+
+import it.rate.webapp.config.Constraints;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.Range;
+
+public record PlaceInDTO(
+    @NotBlank @Length(min = Constraints.MIN_NAME_LENGTH, max = Constraints.MAX_NAME_LENGTH)
+        String name,
+    @Length(max = Constraints.MAX_VARCHAR_LENGTH) String address,
+    @Length(max = Constraints.MAX_DESCRIPTION_LENGTH) String description,
+    @NotNull @Range(min = -90, max = 90) Double latitude,
+    @NotNull @Range(min = -180, max = 180) Double longitude) {}

--- a/src/main/java/it/rate/webapp/dtos/SignupUserInDTO.java
+++ b/src/main/java/it/rate/webapp/dtos/SignupUserInDTO.java
@@ -1,16 +1,28 @@
 package it.rate.webapp.dtos;
 
+import it.rate.webapp.config.Constraints;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.Length;
 
 public record SignupUserInDTO(
     @NotBlank(message = "Email cannot be empty") @Email(message = "Invalid email address")
         String email,
     @NotBlank(message = "Password cannot be empty")
         @Pattern(
-            regexp = "^(?=.*[A-Z])(?=.*[0-9]).{8,}$",
+            regexp = Constraints.PASSWORD_REGEX,
             message =
                 "Password needs to be at least 8 characters long and contain at least one uppercase letter and one digit")
         String password,
-    @NotBlank(message = "Username cannot be empty") String username) {}
+    @NotBlank(message = "Username cannot be empty")
+        @Length(
+            min = Constraints.MIN_USERNAME_LENGTH,
+            max = Constraints.MAX_USERNAME_LENGTH,
+            message =
+                "Username has to be between "
+                    + Constraints.MIN_USERNAME_LENGTH
+                    + " and "
+                    + Constraints.MAX_USERNAME_LENGTH
+                    + " characters long")
+        String username) {}

--- a/src/main/java/it/rate/webapp/models/AppUser.java
+++ b/src/main/java/it/rate/webapp/models/AppUser.java
@@ -35,6 +35,7 @@ public class AppUser {
 
   @NotBlank
   @Pattern(regexp = Constraints.PASSWORD_REGEX)
+  @Length(max = Constraints.MAX_VARCHAR_LENGTH)
   @Column(nullable = false)
   private String password;
 

--- a/src/main/java/it/rate/webapp/models/AppUser.java
+++ b/src/main/java/it/rate/webapp/models/AppUser.java
@@ -1,11 +1,14 @@
 package it.rate.webapp.models;
 
+import it.rate.webapp.config.Constraints;
 import it.rate.webapp.config.ServerRole;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +24,7 @@ public class AppUser {
   @Id @GeneratedValue @NotNull private Long id;
 
   @NotBlank
+  @Length(min = Constraints.MIN_USERNAME_LENGTH, max = Constraints.MAX_USERNAME_LENGTH)
   @Column(nullable = false, unique = true)
   private String username;
 
@@ -30,6 +34,7 @@ public class AppUser {
   private String email;
 
   @NotBlank
+  @Pattern(regexp = Constraints.PASSWORD_REGEX)
   @Column(nullable = false)
   private String password;
 

--- a/src/main/java/it/rate/webapp/models/Category.java
+++ b/src/main/java/it/rate/webapp/models/Category.java
@@ -1,11 +1,13 @@
 package it.rate.webapp.models;
 
+import it.rate.webapp.config.Constraints;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +22,10 @@ public class Category {
   }
 
   @Id @GeneratedValue @NotNull private Long id;
-  @NotBlank private String name;
+
+  @NotBlank
+  @Length(max = Constraints.MAX_NAME_LENGTH)
+  private String name;
 
   @ManyToMany(mappedBy = "categories")
   private List<Interest> interests = new ArrayList<>();

--- a/src/main/java/it/rate/webapp/models/Criterion.java
+++ b/src/main/java/it/rate/webapp/models/Criterion.java
@@ -1,9 +1,11 @@
 package it.rate.webapp.models;
 
+import it.rate.webapp.config.Constraints;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +19,11 @@ import java.util.List;
 @Table(name = "criteria")
 public class Criterion {
   @Id @GeneratedValue @NotNull private Long id;
-  @NotBlank private String name;
+
+  @NotBlank
+  @Length(max = Constraints.MAX_NAME_LENGTH)
+  private String name;
+
   @Builder.Default private boolean deleted = false;
 
   @ManyToOne private Interest interest;

--- a/src/main/java/it/rate/webapp/models/Interest.java
+++ b/src/main/java/it/rate/webapp/models/Interest.java
@@ -69,7 +69,7 @@ public class Interest {
       inverseJoinColumns = @JoinColumn(name = "category_id"))
   private List<Category> categories = new ArrayList<>();
 
-  public Interest(@Valid InterestInDTO interestDTO) {
+  public Interest(@NotNull @Valid InterestInDTO interestDTO) {
     this.name = interestDTO.name();
     this.description = interestDTO.description();
     this.exclusive = interestDTO.exclusive();

--- a/src/main/java/it/rate/webapp/models/Interest.java
+++ b/src/main/java/it/rate/webapp/models/Interest.java
@@ -1,11 +1,14 @@
 package it.rate.webapp.models;
 
 import it.rate.webapp.config.Constraints;
+import it.rate.webapp.dtos.InterestInDTO;
 import jakarta.persistence.*;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,16 +17,16 @@ import java.util.stream.Collectors;
 @Getter
 @Setter
 @Builder
+@Validated
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
 @Table(name = "interests")
 public class Interest {
-  public interface NewInterest {}
 
   @Id
   @GeneratedValue
-  @NotNull(groups = NewInterest.class)
+  @NotNull
   private Long id;
 
   @NotBlank
@@ -65,6 +68,13 @@ public class Interest {
       joinColumns = @JoinColumn(name = "interest_id"),
       inverseJoinColumns = @JoinColumn(name = "category_id"))
   private List<Category> categories = new ArrayList<>();
+
+  public Interest(@Valid InterestInDTO interestDTO) {
+    this.name = interestDTO.name();
+    this.description = interestDTO.description();
+    this.exclusive = interestDTO.exclusive();
+    this.imageName = interestDTO.imageName();
+  }
 
   public int countLikes() {
     return likes.size();

--- a/src/main/java/it/rate/webapp/models/Interest.java
+++ b/src/main/java/it/rate/webapp/models/Interest.java
@@ -3,12 +3,10 @@ package it.rate.webapp.models;
 import it.rate.webapp.config.Constraints;
 import it.rate.webapp.dtos.InterestInDTO;
 import jakarta.persistence.*;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
-import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +15,6 @@ import java.util.stream.Collectors;
 @Getter
 @Setter
 @Builder
-@Validated
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
@@ -69,7 +66,14 @@ public class Interest {
       inverseJoinColumns = @JoinColumn(name = "category_id"))
   private List<Category> categories = new ArrayList<>();
 
-  public Interest(@NotNull @Valid InterestInDTO interestDTO) {
+  public Interest(InterestInDTO interestDTO) {
+    this.name = interestDTO.name();
+    this.description = interestDTO.description();
+    this.exclusive = interestDTO.exclusive();
+    this.imageName = interestDTO.imageName();
+  }
+
+  public void update(InterestInDTO interestDTO) {
     this.name = interestDTO.name();
     this.description = interestDTO.description();
     this.exclusive = interestDTO.exclusive();

--- a/src/main/java/it/rate/webapp/models/Interest.java
+++ b/src/main/java/it/rate/webapp/models/Interest.java
@@ -19,23 +19,20 @@ import java.util.stream.Collectors;
 @Entity
 @Table(name = "interests")
 public class Interest {
-  public interface ExistingInterest {}
+  public interface NewInterest {}
 
-  @Id
-  @GeneratedValue
-  @NotNull
-  private Long id;
+  @Id @GeneratedValue @NotNull private Long id;
 
-  @NotBlank(groups = ExistingInterest.class)
+  @NotBlank(groups = NewInterest.class)
   @Length(
       min = Constraints.MIN_NAME_LENGTH,
       max = Constraints.MAX_NAME_LENGTH,
-      groups = ExistingInterest.class)
+      groups = NewInterest.class)
   @Column(nullable = false)
   private String name;
 
-  @NotBlank(groups = ExistingInterest.class)
-  @Length(max = Constraints.MAX_DESCRIPTION_LENGTH, groups = ExistingInterest.class)
+  @NotBlank(groups = NewInterest.class)
+  @Length(max = Constraints.MAX_DESCRIPTION_LENGTH, groups = NewInterest.class)
   @Column(nullable = false, length = 1000)
   private String description;
 

--- a/src/main/java/it/rate/webapp/models/Interest.java
+++ b/src/main/java/it/rate/webapp/models/Interest.java
@@ -24,7 +24,7 @@ public class Interest {
   private String name;
 
   @NotBlank
-  @Column(nullable = false)
+  @Column(nullable = false, length = 1000)
   private String description;
 
   @Builder.Default private boolean deleted = false;

--- a/src/main/java/it/rate/webapp/models/Interest.java
+++ b/src/main/java/it/rate/webapp/models/Interest.java
@@ -21,18 +21,18 @@ import java.util.stream.Collectors;
 public class Interest {
   public interface NewInterest {}
 
-  @Id @GeneratedValue @NotNull private Long id;
+  @Id
+  @GeneratedValue
+  @NotNull(groups = NewInterest.class)
+  private Long id;
 
-  @NotBlank(groups = NewInterest.class)
-  @Length(
-      min = Constraints.MIN_NAME_LENGTH,
-      max = Constraints.MAX_NAME_LENGTH,
-      groups = NewInterest.class)
+  @NotBlank
+  @Length(min = Constraints.MIN_NAME_LENGTH, max = Constraints.MAX_NAME_LENGTH)
   @Column(nullable = false)
   private String name;
 
-  @NotBlank(groups = NewInterest.class)
-  @Length(max = Constraints.MAX_DESCRIPTION_LENGTH, groups = NewInterest.class)
+  @NotBlank
+  @Length(max = Constraints.MAX_DESCRIPTION_LENGTH)
   @Column(nullable = false, length = 1000)
   private String description;
 

--- a/src/main/java/it/rate/webapp/models/Interest.java
+++ b/src/main/java/it/rate/webapp/models/Interest.java
@@ -19,19 +19,28 @@ import java.util.stream.Collectors;
 @Entity
 @Table(name = "interests")
 public class Interest {
-  @Id @GeneratedValue @NotNull private Long id;
+  public interface ExistingInterest {}
 
-  @NotBlank
-  @Length(min = Constraints.MIN_NAME_LENGTH, max = Constraints.MAX_NAME_LENGTH)
+  @Id
+  @GeneratedValue
+  @NotNull
+  private Long id;
+
+  @NotBlank(groups = ExistingInterest.class)
+  @Length(
+      min = Constraints.MIN_NAME_LENGTH,
+      max = Constraints.MAX_NAME_LENGTH,
+      groups = ExistingInterest.class)
   @Column(nullable = false)
   private String name;
 
-  @NotBlank
-  @Length(max = Constraints.MAX_DESCRIPTION_LENGTH)
+  @NotBlank(groups = ExistingInterest.class)
+  @Length(max = Constraints.MAX_DESCRIPTION_LENGTH, groups = ExistingInterest.class)
   @Column(nullable = false, length = 1000)
   private String description;
 
   @Builder.Default private boolean deleted = false;
+
   private boolean exclusive;
 
   private String imageName;

--- a/src/main/java/it/rate/webapp/models/Interest.java
+++ b/src/main/java/it/rate/webapp/models/Interest.java
@@ -1,9 +1,11 @@
 package it.rate.webapp.models;
 
+import it.rate.webapp.config.Constraints;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,10 +22,12 @@ public class Interest {
   @Id @GeneratedValue @NotNull private Long id;
 
   @NotBlank
+  @Length(min = Constraints.MIN_NAME_LENGTH, max = Constraints.MAX_NAME_LENGTH)
   @Column(nullable = false)
   private String name;
 
   @NotBlank
+  @Length(max = Constraints.MAX_DESCRIPTION_LENGTH)
   @Column(nullable = false, length = 1000)
   private String description;
 

--- a/src/main/java/it/rate/webapp/models/Place.java
+++ b/src/main/java/it/rate/webapp/models/Place.java
@@ -62,7 +62,7 @@ public class Place {
   @Builder.Default
   private List<Rating> ratings = new ArrayList<>();
 
-  public Place(@Valid PlaceInDTO placeDTO) {
+  public Place(@NotNull @Valid PlaceInDTO placeDTO) {
     this.name = placeDTO.name();
     this.address = placeDTO.address();
     this.description = placeDTO.description();
@@ -79,11 +79,11 @@ public class Place {
     return averageRating;
   }
 
-  public void update(@Valid PlaceInDTO placeDTO) {
-    this.setName(placeDTO.name());
-    this.setAddress(placeDTO.address());
-    this.setDescription(placeDTO.description());
-    this.setLatitude(placeDTO.latitude());
-    this.setLongitude(placeDTO.longitude());
+  public void update(@NotNull @Valid PlaceInDTO placeDTO) {
+    this.name = placeDTO.name();
+    this.address = placeDTO.address();
+    this.description = placeDTO.description();
+    this.latitude = placeDTO.latitude();
+    this.longitude = placeDTO.longitude();
   }
 }

--- a/src/main/java/it/rate/webapp/models/Place.java
+++ b/src/main/java/it/rate/webapp/models/Place.java
@@ -1,9 +1,11 @@
 package it.rate.webapp.models;
 
+import it.rate.webapp.config.Constraints;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
 
 import java.util.ArrayList;
@@ -21,12 +23,15 @@ public class Place {
   @Id @GeneratedValue @NotNull private Long id;
 
   @NotBlank
+  @Length(min = Constraints.MIN_NAME_LENGTH, max = Constraints.MAX_NAME_LENGTH)
   @Column(nullable = false)
   private String name;
 
+  @Length(max = Constraints.MAX_DESCRIPTION_LENGTH)
   @Column(length = 1000)
   private String description;
 
+  @Length(max = Constraints.MAX_VARCHAR_LENGTH)
   private String address;
 
   @NotNull

--- a/src/main/java/it/rate/webapp/models/Place.java
+++ b/src/main/java/it/rate/webapp/models/Place.java
@@ -24,7 +24,9 @@ public class Place {
   @Column(nullable = false)
   private String name;
 
+  @Column(length = 1000)
   private String description;
+
   private String address;
 
   @NotNull

--- a/src/main/java/it/rate/webapp/models/Place.java
+++ b/src/main/java/it/rate/webapp/models/Place.java
@@ -3,13 +3,11 @@ package it.rate.webapp.models;
 import it.rate.webapp.config.Constraints;
 import it.rate.webapp.dtos.PlaceInDTO;
 import jakarta.persistence.*;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
-import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +16,6 @@ import java.util.OptionalDouble;
 @Getter
 @Setter
 @Builder
-@Validated
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
@@ -62,7 +59,7 @@ public class Place {
   @Builder.Default
   private List<Rating> ratings = new ArrayList<>();
 
-  public Place(@NotNull @Valid PlaceInDTO placeDTO) {
+  public Place(PlaceInDTO placeDTO) {
     this.name = placeDTO.name();
     this.address = placeDTO.address();
     this.description = placeDTO.description();
@@ -79,7 +76,7 @@ public class Place {
     return averageRating;
   }
 
-  public void update(@NotNull @Valid PlaceInDTO placeDTO) {
+  public void update(PlaceInDTO placeDTO) {
     this.name = placeDTO.name();
     this.address = placeDTO.address();
     this.description = placeDTO.description();

--- a/src/main/java/it/rate/webapp/models/Place.java
+++ b/src/main/java/it/rate/webapp/models/Place.java
@@ -1,12 +1,15 @@
 package it.rate.webapp.models;
 
 import it.rate.webapp.config.Constraints;
+import it.rate.webapp.dtos.PlaceInDTO;
 import jakarta.persistence.*;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +18,7 @@ import java.util.OptionalDouble;
 @Getter
 @Setter
 @Builder
+@Validated
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
@@ -58,6 +62,14 @@ public class Place {
   @Builder.Default
   private List<Rating> ratings = new ArrayList<>();
 
+  public Place(@Valid PlaceInDTO placeDTO) {
+    this.name = placeDTO.name();
+    this.address = placeDTO.address();
+    this.description = placeDTO.description();
+    this.latitude = placeDTO.latitude();
+    this.longitude = placeDTO.longitude();
+  }
+
   public Double getAverageRating() {
     Double averageRating = null;
     OptionalDouble optAverageRating = ratings.stream().mapToDouble(Rating::getRating).average();
@@ -65,5 +77,13 @@ public class Place {
       averageRating = optAverageRating.getAsDouble();
     }
     return averageRating;
+  }
+
+  public void update(@Valid PlaceInDTO placeDTO) {
+    this.setName(placeDTO.name());
+    this.setAddress(placeDTO.address());
+    this.setDescription(placeDTO.description());
+    this.setLatitude(placeDTO.latitude());
+    this.setLongitude(placeDTO.longitude());
   }
 }

--- a/src/main/java/it/rate/webapp/services/CategoryService.java
+++ b/src/main/java/it/rate/webapp/services/CategoryService.java
@@ -1,5 +1,6 @@
 package it.rate.webapp.services;
 
+import it.rate.webapp.config.Constraints;
 import it.rate.webapp.models.Category;
 import it.rate.webapp.repositories.CategoryRepository;
 import jakarta.validation.constraints.Size;
@@ -15,21 +16,17 @@ import java.util.Set;
 @AllArgsConstructor
 public class CategoryService {
   private final CategoryRepository categoryRepository;
-  private final int MAX_CATEGORIES_PER_INTEREST = 3;
 
   public List<Category> findAll() {
     return categoryRepository.findAll();
-  }
-
-  public int getMaxCategories() {
-    return this.MAX_CATEGORIES_PER_INTEREST;
   }
 
   public List<Category> findAllByIdIn(Set<Long> ids) {
     return categoryRepository.findAllByIdIn(ids);
   }
 
-  public List<Category> findMaxLimitByIdIn(@Size(max = MAX_CATEGORIES_PER_INTEREST) Set<Long> ids) {
+  public List<Category> findMaxLimitByIdIn(
+      @Size(max = Constraints.MAX_CATEGORIES_PER_INTEREST) Set<Long> ids) {
     return findAllByIdIn(ids);
   }
 }

--- a/src/main/java/it/rate/webapp/services/CriterionService.java
+++ b/src/main/java/it/rate/webapp/services/CriterionService.java
@@ -33,7 +33,8 @@ public class CriterionService {
   }
 
   public void updateExisting(
-      @Valid Interest interest, @NotEmpty Set<@NotBlank String> criteriaNames) {
+      @Valid Interest interest,
+      @NotEmpty Set<@NotBlank @Length(max = Constraints.MAX_NAME_LENGTH) String> criteriaNames) {
     // Get old criteria
     List<Criterion> oldCriteria = criterionRepository.findAllByInterest(interest);
 

--- a/src/main/java/it/rate/webapp/services/CriterionService.java
+++ b/src/main/java/it/rate/webapp/services/CriterionService.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 public class CriterionService {
   private final CriterionRepository criterionRepository;
 
-  public void createNew(
+  public void saveAll(
       @Valid Interest interest,
       @NotEmpty Set<@NotBlank @Length(max = Constraints.MAX_NAME_LENGTH) String> criteriaNames) {
     List<Criterion> criteria =
@@ -32,7 +32,7 @@ public class CriterionService {
     criterionRepository.saveAll(criteria);
   }
 
-  public void updateExisting(
+  public void updateAll(
       @Valid Interest interest,
       @NotEmpty Set<@NotBlank @Length(max = Constraints.MAX_NAME_LENGTH) String> criteriaNames) {
     // Get old criteria

--- a/src/main/java/it/rate/webapp/services/CriterionService.java
+++ b/src/main/java/it/rate/webapp/services/CriterionService.java
@@ -1,5 +1,6 @@
 package it.rate.webapp.services;
 
+import it.rate.webapp.config.Constraints;
 import it.rate.webapp.models.Criterion;
 import it.rate.webapp.models.Interest;
 import it.rate.webapp.repositories.CriterionRepository;
@@ -7,6 +8,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
@@ -20,7 +22,9 @@ import java.util.stream.Collectors;
 public class CriterionService {
   private final CriterionRepository criterionRepository;
 
-  public void createNew(@Valid Interest interest, @NotEmpty Set<@NotBlank String> criteriaNames) {
+  public void createNew(
+      @Valid Interest interest,
+      @NotEmpty Set<@NotBlank @Length(max = Constraints.MAX_NAME_LENGTH) String> criteriaNames) {
     List<Criterion> criteria =
         criteriaNames.stream()
             .map(c -> Criterion.builder().name(c).interest(interest).build())

--- a/src/main/java/it/rate/webapp/services/InterestService.java
+++ b/src/main/java/it/rate/webapp/services/InterestService.java
@@ -1,7 +1,6 @@
 package it.rate.webapp.services;
 
 import it.rate.webapp.dtos.CoordinatesDTO;
-import it.rate.webapp.dtos.InterestInDTO;
 import it.rate.webapp.dtos.InterestSuggestionDTO;
 import it.rate.webapp.dtos.LikedInterestsDTO;
 import it.rate.webapp.models.*;

--- a/src/main/java/it/rate/webapp/services/InterestService.java
+++ b/src/main/java/it/rate/webapp/services/InterestService.java
@@ -1,6 +1,7 @@
 package it.rate.webapp.services;
 
 import it.rate.webapp.dtos.CoordinatesDTO;
+import it.rate.webapp.dtos.InterestInDTO;
 import it.rate.webapp.dtos.InterestSuggestionDTO;
 import it.rate.webapp.dtos.LikedInterestsDTO;
 import it.rate.webapp.models.*;
@@ -19,8 +20,6 @@ import org.springframework.validation.annotation.Validated;
 @AllArgsConstructor
 public class InterestService {
 
-  private final Validator validator;
-
   private final InterestRepository interestRepository;
 
   public Optional<Interest> findById(Long interestId) {
@@ -31,16 +30,11 @@ public class InterestService {
     return interestRepository.getReferenceById(interestId);
   }
 
-  public Interest saveNew(@Valid Interest interest) {
+  public Interest save(Interest interest) {
     return interestRepository.save(interest);
   }
 
-  public Interest saveEdited(@Valid Interest interest) {
-    Set<ConstraintViolation<Interest>> violations =
-        validator.validate(interest, Interest.NewInterest.class);
-    if (!violations.isEmpty()) {
-      throw new ConstraintViolationException(violations);
-    }
+  public Interest update(@Valid Interest interest) {
     return interestRepository.save(interest);
   }
 

--- a/src/main/java/it/rate/webapp/services/InterestService.java
+++ b/src/main/java/it/rate/webapp/services/InterestService.java
@@ -1,6 +1,7 @@
 package it.rate.webapp.services;
 
 import it.rate.webapp.dtos.CoordinatesDTO;
+import it.rate.webapp.dtos.InterestInDTO;
 import it.rate.webapp.dtos.InterestSuggestionDTO;
 import it.rate.webapp.dtos.LikedInterestsDTO;
 import it.rate.webapp.models.*;
@@ -10,6 +11,7 @@ import jakarta.validation.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
@@ -20,6 +22,7 @@ import org.springframework.validation.annotation.Validated;
 public class InterestService {
 
   private final InterestRepository interestRepository;
+  private final CategoryService categoryService;
 
   public Optional<Interest> findById(Long interestId) {
     return interestRepository.findById(interestId);
@@ -29,11 +32,15 @@ public class InterestService {
     return interestRepository.getReferenceById(interestId);
   }
 
-  public Interest save(Interest interest) {
+  public Interest save(@NotNull @Valid InterestInDTO interestDTO) {
+    Interest interest = new Interest(interestDTO);
+    interest.setCategories(categoryService.findMaxLimitByIdIn(interestDTO.categoryIds()));
     return interestRepository.save(interest);
   }
 
-  public Interest update(@Valid Interest interest) {
+  public Interest update(@Valid Interest interest, @NotNull @Valid InterestInDTO interestDTO) {
+    interest.setCategories(categoryService.findMaxLimitByIdIn(interestDTO.categoryIds()));
+    interest.update(interestDTO);
     return interestRepository.save(interest);
   }
 

--- a/src/main/java/it/rate/webapp/services/InterestService.java
+++ b/src/main/java/it/rate/webapp/services/InterestService.java
@@ -31,16 +31,16 @@ public class InterestService {
     return interestRepository.getReferenceById(interestId);
   }
 
-  public Interest saveNew(Interest interest) {
-    Set<ConstraintViolation<Interest>> violations =
-            validator.validate(interest, Interest.NewInterest.class);
-    if (!violations.isEmpty()) {
-      throw new ConstraintViolationException(violations);
-    }
+  public Interest saveNew(@Valid Interest interest) {
     return interestRepository.save(interest);
   }
 
   public Interest saveEdited(@Valid Interest interest) {
+    Set<ConstraintViolation<Interest>> violations =
+        validator.validate(interest, Interest.NewInterest.class);
+    if (!violations.isEmpty()) {
+      throw new ConstraintViolationException(violations);
+    }
     return interestRepository.save(interest);
   }
 

--- a/src/main/java/it/rate/webapp/services/InterestService.java
+++ b/src/main/java/it/rate/webapp/services/InterestService.java
@@ -5,9 +5,11 @@ import it.rate.webapp.dtos.InterestSuggestionDTO;
 import it.rate.webapp.dtos.LikedInterestsDTO;
 import it.rate.webapp.models.*;
 import it.rate.webapp.repositories.*;
-import jakarta.validation.Valid;
+import jakarta.validation.*;
+
 import java.util.*;
 import java.util.stream.Collectors;
+
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
@@ -16,6 +18,8 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 @AllArgsConstructor
 public class InterestService {
+
+  private final Validator validator;
 
   private final InterestRepository interestRepository;
 
@@ -27,7 +31,16 @@ public class InterestService {
     return interestRepository.getReferenceById(interestId);
   }
 
-  public Interest save(Interest interest) {
+  public Interest saveNew(@Valid Interest interest) {
+    return interestRepository.save(interest);
+  }
+
+  public Interest saveEdited(Interest interest) {
+    Set<ConstraintViolation<Interest>> violations =
+        validator.validate(interest, Interest.ExistingInterest.class);
+    if (!violations.isEmpty()) {
+      throw new ConstraintViolationException(violations);
+    }
     return interestRepository.save(interest);
   }
 

--- a/src/main/java/it/rate/webapp/services/InterestService.java
+++ b/src/main/java/it/rate/webapp/services/InterestService.java
@@ -31,16 +31,16 @@ public class InterestService {
     return interestRepository.getReferenceById(interestId);
   }
 
-  public Interest saveNew(@Valid Interest interest) {
-    return interestRepository.save(interest);
-  }
-
-  public Interest saveEdited(Interest interest) {
+  public Interest saveNew(Interest interest) {
     Set<ConstraintViolation<Interest>> violations =
-        validator.validate(interest, Interest.ExistingInterest.class);
+            validator.validate(interest, Interest.NewInterest.class);
     if (!violations.isEmpty()) {
       throw new ConstraintViolationException(violations);
     }
+    return interestRepository.save(interest);
+  }
+
+  public Interest saveEdited(@Valid Interest interest) {
     return interestRepository.save(interest);
   }
 

--- a/src/main/java/it/rate/webapp/services/PlaceService.java
+++ b/src/main/java/it/rate/webapp/services/PlaceService.java
@@ -14,6 +14,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
@@ -34,14 +35,15 @@ public class PlaceService {
     return placeRepository.getReferenceById(placeId);
   }
 
-  public Place save(Place place, @Valid Interest interest, @Valid AppUser appUser) {
+  public Place save(@NotNull @Valid PlaceInDTO placeDTO, @Valid Interest interest, @Valid AppUser appUser) {
+    Place place = new Place(placeDTO);
     place.setCreator(appUser);
     place.setInterest(interest);
 
     return placeRepository.save(place);
   }
 
-  public Place update(@Valid Place place, PlaceInDTO placeDTO) {
+  public Place update(@Valid Place place, @NotNull @Valid PlaceInDTO placeDTO) {
     place.update(placeDTO);
     return placeRepository.save(place);
   }

--- a/src/main/java/it/rate/webapp/services/PlaceService.java
+++ b/src/main/java/it/rate/webapp/services/PlaceService.java
@@ -2,6 +2,7 @@ package it.rate.webapp.services;
 
 import it.rate.webapp.dtos.CriteriaOfPlaceDTO;
 import it.rate.webapp.dtos.CriterionAvgRatingDTO;
+import it.rate.webapp.dtos.PlaceInDTO;
 import it.rate.webapp.dtos.PlaceInfoDTO;
 import it.rate.webapp.models.*;
 import it.rate.webapp.models.AppUser;
@@ -37,6 +38,11 @@ public class PlaceService {
     place.setCreator(appUser);
     place.setInterest(interest);
 
+    return placeRepository.save(place);
+  }
+
+  public Place update(@Valid Place place, PlaceInDTO placeDTO) {
+    place.update(placeDTO);
     return placeRepository.save(place);
   }
 

--- a/src/main/java/it/rate/webapp/services/RatingService.java
+++ b/src/main/java/it/rate/webapp/services/RatingService.java
@@ -7,6 +7,7 @@ import it.rate.webapp.models.*;
 import it.rate.webapp.repositories.CriterionRepository;
 import it.rate.webapp.repositories.RatingRepository;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
@@ -26,7 +27,7 @@ public class RatingService {
     return new RatingsDTO(ratings);
   }
 
-  public void updateRating(@Valid RatingsDTO ratings, @Valid Place place, @Valid AppUser appUser) {
+  public void updateRating(@NotNull @Valid RatingsDTO ratings, @Valid Place place, @Valid AppUser appUser) {
     Set<Criterion> ratedCriteria = validateRatings(ratings, place);
 
     ratings

--- a/src/main/java/it/rate/webapp/services/RoleService.java
+++ b/src/main/java/it/rate/webapp/services/RoleService.java
@@ -31,7 +31,7 @@ public class RoleService {
   }
 
   public void setRole(
-      @Valid @NotNull Interest interest, @Valid @NotNull AppUser appUser, @NotNull Role.RoleType roleType) {
+          @NotNull @Valid Interest interest, @NotNull @Valid AppUser appUser, @NotNull Role.RoleType roleType) {
     if (interest.isExclusive() || roleType.equals(Role.RoleType.CREATOR)) {
       roleRepository.save(new Role(appUser, interest, roleType));
     } else {

--- a/src/main/java/it/rate/webapp/utils/ThymeMath.java
+++ b/src/main/java/it/rate/webapp/utils/ThymeMath.java
@@ -1,4 +1,4 @@
-package it.rate.webapp.config;
+package it.rate.webapp.utils;
 
 import org.springframework.stereotype.Component;
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -12,7 +12,7 @@ spring.mvc.hiddenmethod.filter.enabled=true
 
 UPLOAD_DIRECTORY=1XhELlnKfa8v0oPFjdfburfdGfoTR5dfq
 
-advice.enabled=false
+advice.enabled=true
 
 #Set max size for upload
 spring.servlet.multipart.max-file-size=5MB

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -12,7 +12,7 @@ spring.mvc.hiddenmethod.filter.enabled=true
 
 UPLOAD_DIRECTORY=1XhELlnKfa8v0oPFjdfburfdGfoTR5dfq
 
-advice.enabled=true
+advice.enabled=false
 
 #Set max size for upload
 spring.servlet.multipart.max-file-size=5MB

--- a/src/main/resources/static/scripts/inputForm.js
+++ b/src/main/resources/static/scripts/inputForm.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', function() {
+    updateCharCountAndResize(document.querySelector("#description").getAttribute("maxlength"));
+})
+
+function updateCharCountAndResize(maxLength) {
+    const textarea = document.querySelector("#description");
+    const charCount = document.querySelector("#charCount");
+    const remainingChars = maxLength - textarea.value.length;
+    charCount.textContent = "Characters remaining: " + remainingChars;
+    textarea.style.height = "auto";
+    textarea.style.height = textarea.scrollHeight + "px";
+}
+
+
+

--- a/src/main/resources/static/scripts/interestForm.js
+++ b/src/main/resources/static/scripts/interestForm.js
@@ -1,9 +1,9 @@
 function addCriteria() {
-    var criteriaContainer = document.getElementById('criteriaContainer');
-    var div = document.createElement('div');
-    var label = document.createElement('label')
-    var input = document.createElement('input');
-    var removeButton = document.createElement('button');
+    const criteriaContainer = document.getElementById('criteriaContainer');
+    const div = document.createElement('div');
+    const label = document.createElement('label')
+    const input = document.createElement('input');
+    const removeButton = document.createElement('button');
     const img = document.createElement('img');
     img.src = '/icons/cross.svg';
 
@@ -33,10 +33,10 @@ function addCriteria() {
     div.appendChild(label);
     criteriaContainer.appendChild(div);
 
-    var criteriaForm = document.getElementById('criteriaForm');
+    const criteriaForm = document.getElementById('criteriaForm');
     criteriaForm.addEventListener('submit', function (event) {
-        var criteriaInputs = document.querySelectorAll('input[name="criteriaNames"]');
-        var isValid = true;
+        const criteriaInputs = document.querySelectorAll('input[name="criteriaNames"]');
+        let isValid = true;
 
         criteriaInputs.forEach(function (input) {
             if (input.value.trim() === '') {
@@ -53,8 +53,8 @@ function addCriteria() {
 }
 
 function removeCriteria(div) {
-    var criteriaContainer = document.getElementById('criteriaContainer');
-    var parentDiv = div || event.currentTarget.closest('div');
+    const criteriaContainer = document.getElementById('criteriaContainer');
+    const parentDiv = div || event.currentTarget.closest('div');
     if (parentDiv) {
         if (parentDiv !== criteriaContainer.firstElementChild || criteriaContainer.children.length > 1) {
             parentDiv.remove();
@@ -63,7 +63,7 @@ function removeCriteria(div) {
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-    var removeButtons = document.querySelectorAll('#criteriaContainer button');
+    const removeButtons = document.querySelectorAll('#criteriaContainer button');
     removeButtons.forEach(function (button) {
         button.onclick = function () {
             removeCriteria(null, button.closest('div'));
@@ -94,4 +94,11 @@ function disableCategoryIfMax() {
             checkbox.disabled = false;
         });
     }
+}
+
+function setRateAccess() {
+    const checkbox = document.getElementById('toggle')
+    const exclusive = document.getElementById('exclusive')
+    //easter egg
+    exclusive.value = !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!checkbox.checked;
 }

--- a/src/main/resources/static/scripts/interestForm.js
+++ b/src/main/resources/static/scripts/interestForm.js
@@ -34,23 +34,25 @@ function addCriteria(maxLength) {
     div.appendChild(label);
     criteriaContainer.appendChild(div);
 
-    const criteriaForm = document.getElementById('criteriaForm');
-    criteriaForm.addEventListener('submit', function (event) {
-        const criteriaInputs = document.querySelectorAll('input[name="criteriaNames"]');
-        let isValid = true;
+    //this currently does not work because criteriaForm id does not exist in the form
 
-        criteriaInputs.forEach(function (input) {
-            if (input.value.trim() === '') {
-                isValid = false;
-                input.classList.add('invalid-field');
-            }
-        });
-
-        if (!isValid) {
-            event.preventDefault();
-            alert('Please fill in all criteria fields.');
-        }
-    });
+    // const criteriaForm = document.getElementById('criteriaForm');
+    // criteriaForm.addEventListener('submit', function (event) {
+    //     const criteriaInputs = document.querySelectorAll('input[name="criteriaNames"]');
+    //     let isValid = true;
+    //
+    //     criteriaInputs.forEach(function (input) {
+    //         if (input.value.trim() === '') {
+    //             isValid = false;
+    //             input.classList.add('invalid-field');
+    //         }
+    //     });
+    //
+    //     if (!isValid) {
+    //         event.preventDefault();
+    //         alert('Please fill in all criteria fields.');
+    //     }
+    // });
 }
 
 function removeCriteria(div) {

--- a/src/main/resources/static/scripts/interestForm.js
+++ b/src/main/resources/static/scripts/interestForm.js
@@ -1,4 +1,4 @@
-function addCriteria() {
+function addCriteria(maxLength) {
     const criteriaContainer = document.getElementById('criteriaContainer');
     const div = document.createElement('div');
     const label = document.createElement('label')
@@ -13,6 +13,7 @@ function addCriteria() {
     input.name = 'criteriaNames';
     input.required = true;
     input.classList.add('input-text-field');
+    input.maxLength = maxLength;
 
     removeButton.type = 'button';
     removeButton.textContent = '';

--- a/src/main/resources/static/styles/index.css
+++ b/src/main/resources/static/styles/index.css
@@ -753,6 +753,7 @@ h4 {
     border: none;
     margin: 0.2rem 0 0.2rem 0;
     width: 100%;
+    resize: none;
 }
 
 .new-place-map {
@@ -1189,4 +1190,9 @@ h4 {
     white-space: normal;
     font-size: small;
     margin-bottom: 0;
+}
+
+#charCount {
+    margin-bottom: 0.5rem;
+    color: #888585;
 }

--- a/src/main/resources/static/styles/index.css
+++ b/src/main/resources/static/styles/index.css
@@ -857,6 +857,7 @@ h4 {
 .error {
     color: #d74141;
     font-weight: 600;
+    padding: 1.2rem
 }
 
 .successful {

--- a/src/main/resources/templates/interest/form.html
+++ b/src/main/resources/templates/interest/form.html
@@ -104,7 +104,7 @@
 <script type="module" src="/scripts/interestImageUpload.js"></script>
 <script src="/scripts/interestForm.js"></script>
 <script th:inline="javascript">
-    const MAX_CATEGORIES = [[${maxCategories}]];
+    const MAX_CATEGORIES = [[${@constraints.MAX_CATEGORIES_PER_INTEREST}]];
 </script>
 
 </body>

--- a/src/main/resources/templates/interest/form.html
+++ b/src/main/resources/templates/interest/form.html
@@ -21,7 +21,11 @@
             <section class="input-param">
                 <h4>Name</h4>
                 <label>
-                    <input class="input-text-field" type="text" name="name" th:value="*{name}" required>
+                    <input class="input-text-field"
+                           type="text" name="name"
+                           th:value="*{name}"
+                           required
+                    />
                 </label>
             </section>
 
@@ -29,7 +33,12 @@
                 <h4>Category</h4>
                 <div class="sort-buttons">
                     <label class="sort-container" th:each="category : ${categories}">
-                        <input th:checked="${interest.categoryIds.contains(category.id)}" type="checkbox" name="categoryIds" th:value="${category.id}" class="sort-checkbox"/>
+                        <input class="sort-checkbox"
+                               name="categoryIds"
+                               type="checkbox"
+                               th:checked="${interest.categoryIds.contains(category.id)}"
+                               th:value="${category.id}"
+                        />
                         <span th:text="${category.name}"></span>
                     </label>
                 </div>
@@ -37,7 +46,13 @@
 
             <section class="input-param">
                 <h4>Rate access</h4>
-                <input type="checkbox" id="toggle" class="toggle-checkbox" name="exclusive" th:checked="*{exclusive}"/>
+                <input type="hidden" th:field="*{exclusive}">
+                <input class="toggle-checkbox"
+                       id="toggle"
+                       type="checkbox"
+                       th:checked="*{exclusive}"
+                       onchange="setRateAccess()"
+                />
                 <label for="toggle" class="toggle-container">
                     <span>Anyone can rate</span>
                     <span>Invite only</span>
@@ -81,7 +96,7 @@
             <section class="input-param">
                 <h4>Description</h4>
                 <label>
-                    <textarea class="input-text-field" name="description" th:field="*{description}" required></textarea>
+                    <textarea class="input-text-field" th:field="*{description}" required></textarea>
                 </label>
             </section>
 
@@ -94,7 +109,7 @@
                 <button class="button" type="submit">Save</button>
             </div>
 
-            <input type="hidden" id="uploadedImageId" name="uploadedImageId" th:field="*{imageName}"/>
+            <input type="hidden" id="uploadedImageId" th:field="*{imageName}"/>
 
         </form>
     </main>

--- a/src/main/resources/templates/interest/form.html
+++ b/src/main/resources/templates/interest/form.html
@@ -98,11 +98,15 @@
             </section>
 
             <section class="input-param">
-                <h4>Description</h4>
+                    <h4>Description</h4>
                 <label>
                     <textarea class="input-text-field" th:field="*{description}"
-                              th:maxlength="${@constraints.MAX_DESCRIPTION_LENGTH}" required></textarea>
+                              th:maxlength="${@constraints.MAX_DESCRIPTION_LENGTH}"
+                              th:oninput="'updateCharCountAndResize(' + ${@constraints.MAX_DESCRIPTION_LENGTH} + ')'"
+                              required>
+                    </textarea>
                 </label>
+                <p id="charCount"></p>
             </section>
 
             <div id="uppy"></div>
@@ -123,6 +127,7 @@
 
 <script type="module" src="/scripts/interestImageUpload.js"></script>
 <script src="/scripts/interestForm.js"></script>
+<script src="/scripts/inputForm.js"></script>
 <script th:inline="javascript">
     const MAX_CATEGORIES = [[${@constraints.MAX_CATEGORIES_PER_INTEREST}]];
 </script>

--- a/src/main/resources/templates/interest/form.html
+++ b/src/main/resources/templates/interest/form.html
@@ -24,7 +24,7 @@
                     <input class="input-text-field"
                            type="text" name="name"
                            th:value="*{name}"
-                           required
+                           required th:maxlength="${@constraints.MAX_NAME_LENGTH}"
                     />
                 </label>
             </section>
@@ -63,18 +63,21 @@
                 <h4>Rating criteria</h4>
                 <div id="criteriaContainer" class="criteria-container">
                     <label th:if="*{id == null}" class="list-record first-criterion">
-                        <input class="input-text-field" type="text" name="criteriaNames" required/>
+                        <input class="input-text-field" type="text" name="criteriaNames"
+                               th:maxlength="${@constraints.MAX_NAME_LENGTH}" required/>
                     </label>
                     <th:block th:if="*{id != null}">
                         <label class="list-record first-criterion">
                             <input class="input-text-field" type="text" name="criteriaNames"
-                                   th:value="${interest.criteria[0]?.name}" required/>
+                                   th:value="${interest.criteria[0]?.name}"
+                                   th:maxlength="${@constraints.MAX_NAME_LENGTH}" required/>
                         </label>
 
                         <div th:each="criterion, iterStat : ${interest.criteria}" th:if="${iterStat.index > 0}">
                             <label class="list-record">
                                 <input class="input-text-field" type="text" name="criteriaNames"
-                                       th:value="${criterion.name}" required/>
+                                       th:value="${criterion.name}" th:maxlength="${@constraints.MAX_NAME_LENGTH}"
+                                       required/>
                                 <button class="role-option-button kick-button" type="button"
                                         onclick="removeCriteria(this, ${iterStat.index})">
                                     <img src="/icons/cross.svg" alt="Kick">
@@ -86,7 +89,8 @@
 
                 <div class="add-criterion">
                     <span>Add criterion</span>
-                    <button class="role-option-button accept-button" type="button" onclick="addCriteria()">
+                    <button class="role-option-button accept-button" type="button"
+                            th:onclick="'addCriteria(' + ${@constraints.MAX_NAME_LENGTH} + ')'">
                         <img src="/icons/add.svg" alt="Add Criterion">
                     </button>
                 </div>
@@ -96,7 +100,8 @@
             <section class="input-param">
                 <h4>Description</h4>
                 <label>
-                    <textarea class="input-text-field" th:field="*{description}" required></textarea>
+                    <textarea class="input-text-field" th:field="*{description}"
+                              th:maxlength="${@constraints.MAX_DESCRIPTION_LENGTH}" required></textarea>
                 </label>
             </section>
 

--- a/src/main/resources/templates/place/form.html
+++ b/src/main/resources/templates/place/form.html
@@ -72,14 +72,16 @@
             </section>
 
             <section class="input-param">
-                <h4>Description</h4>
+                    <h4>Description</h4>
                 <label>
                     <textarea class="input-text-field"
                               id="description"
                               name="description"
-                              th:field="*{description}" th:maxlength="${@constraints.MAX_DESCRIPTION_LENGTH}">
+                              th:field="*{description}" th:maxlength="${@constraints.MAX_DESCRIPTION_LENGTH}"
+                              th:oninput="'updateCharCountAndResize(' + ${@constraints.MAX_DESCRIPTION_LENGTH} + ')'">
                     </textarea>
                 </label>
+                <p id="charCount"></p>
             </section>
 
             <button class="button" type="submit">Save</button>
@@ -93,6 +95,6 @@
     let longitude = [[${place.longitude}]];
 </script>
 <script src="/scripts/placeFormMap.js"></script>
-
+<script src="/scripts/inputForm.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/place/form.html
+++ b/src/main/resources/templates/place/form.html
@@ -32,7 +32,7 @@
                            name="name"
                            th:field="*{name}"
                            required
-                           autocomplete="off">
+                           autocomplete="off" th:maxlength="${@constraints.MAX_NAME_LENGTH}">
                 </label>
             </section>
 
@@ -44,7 +44,7 @@
                            id="address"
                            name="address"
                            th:field="*{address}"
-                           autocomplete="off">
+                           autocomplete="off" th:maxlength="${@constraints.MAX_VARCHAR_LENGTH}">
                 </label>
             </section>
 
@@ -77,7 +77,7 @@
                     <textarea class="input-text-field"
                               id="description"
                               name="description"
-                              th:field="*{description}">
+                              th:field="*{description}" th:maxlength="${@constraints.MAX_DESCRIPTION_LENGTH}">
                     </textarea>
                 </label>
             </section>
@@ -89,12 +89,8 @@
 
 <script th:replace="~{fragments :: leaflet-script}"></script>
 <script th:inline="javascript">
-    /*<![CDATA[*/
-
     let latitude = [[${place.latitude}]];
     let longitude = [[${place.longitude}]];
-
-    /*]]>*/
 </script>
 <script src="/scripts/placeFormMap.js"></script>
 

--- a/src/main/resources/templates/user/loginForm.html
+++ b/src/main/resources/templates/user/loginForm.html
@@ -15,9 +15,6 @@
                 <div class="rs-logo">
                     <img src="/icons/R-logo.png" alt="Logo">
                 </div>
-                <div th:if="${param.error}">
-                    <div class="alert alert-danger">Invalid Username or Password</div>
-                </div>
                 <section class="credentials">
                     <h6>Email address</h6>
                     <input class="credentials-input" type="text" name="username"
@@ -32,6 +29,7 @@
 
                 </section>
                 <a class="forgot-password">Forgot password?</a>
+                <p th:if="${param.error}" class="error">Invalid username or password</p>
                 <div class="user-form-button">
                     <button type="submit" class="sign-button">Login</button>
                 </div>

--- a/src/test/java/it/rate/webapp/BaseIntegrationTest.java
+++ b/src/test/java/it/rate/webapp/BaseIntegrationTest.java
@@ -29,7 +29,7 @@ public class BaseIntegrationTest extends BaseTest {
         AppUser.builder()
             .username("Lojza")
             .email("lojza@lojza.cz")
-            .password("$2a$10$9g1X9rp6meCML3g/h32MyeQ369SEh/hQpZb82eqjpvI71xCIdPAlG")
+            .password("$2a$10$EBJUECPu/pDHhnt9TX3xmOVHVdYlYdAdR997ilX42EzakA/tL6aQC")
             .serverRole(ServerRole.USER)
             .build();
 
@@ -37,7 +37,7 @@ public class BaseIntegrationTest extends BaseTest {
         AppUser.builder()
             .username("Alfonz")
             .email("alfonz@alfonz.cz")
-            .password("$2a$10$9g1X9rp6meCML3g/h32MyeQ369SEh/hQpZb82eqjpvI71xCIdPAlG")
+            .password("$2a$10$EBJUECPu/pDHhnt9TX3xmOVHVdYlYdAdR997ilX42EzakA/tL6aQC")
             .serverRole(ServerRole.USER)
             .build();
 
@@ -45,7 +45,7 @@ public class BaseIntegrationTest extends BaseTest {
         AppUser.builder()
             .username("Karel")
             .email("karel@karel.cz")
-            .password("$2a$10$9g1X9rp6meCML3g/h32MyeQ369SEh/hQpZb82eqjpvI71xCIdPAlG")
+            .password("$2a$10$EBJUECPu/pDHhnt9TX3xmOVHVdYlYdAdR997ilX42EzakA/tL6aQC")
             .serverRole(ServerRole.ADMIN)
             .build();
 
@@ -53,14 +53,14 @@ public class BaseIntegrationTest extends BaseTest {
         AppUser.builder()
             .username("Franta")
             .email("franta@franta.cz")
-            .password("$2a$10$9g1X9rp6meCML3g/h32MyeQ369SEh/hQpZb82eqjpvI71xCIdPAlG")
+            .password("$2a$10$EBJUECPu/pDHhnt9TX3xmOVHVdYlYdAdR997ilX42EzakA/tL6aQC")
             .serverRole(ServerRole.USER)
             .build();
 
     AppUser u5 = AppUser.builder()
             .username("Hynek")
             .email("hynek@hynek.cz")
-            .password("$2a$10$9g1X9rp6meCML3g/h32MyeQ369SEh/hQpZb82eqjpvI71xCIdPAlG")
+            .password("$2a$10$EBJUECPu/pDHhnt9TX3xmOVHVdYlYdAdR997ilX42EzakA/tL6aQC")
             .serverRole(ServerRole.USER)
             .build();
     userRepository.saveAll(List.of(u1, u2, u3, u4, u5));

--- a/src/test/java/it/rate/webapp/controllers/InterestAdminControllerIntegrationTest.java
+++ b/src/test/java/it/rate/webapp/controllers/InterestAdminControllerIntegrationTest.java
@@ -19,7 +19,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -258,7 +257,8 @@ class InterestAdminControllerIntegrationTest extends BaseIntegrationTest {
                 put("/interests/" + interestId + "/admin/edit")
                     .param("name", interestName)
                     .param("description", interestDescription)
-                    .param("criteriaNames", criterion1))
+                    .param("criteriaNames", criterion1)
+                    .param("exclusive", "false"))
             .andExpect(status().is3xxRedirection())
             .andReturn();
 
@@ -289,7 +289,8 @@ class InterestAdminControllerIntegrationTest extends BaseIntegrationTest {
             put("/interests/" + interestId + "/admin/edit")
                 .param("name", interestName)
                 .param("description", interestDescription)
-                .param("criteriaNames", criterion1))
+                .param("criteriaNames", criterion1)
+                .param("exclusive", "false"))
         .andExpect(status().isForbidden())
         .andExpect(view().name("error/page"))
         .andReturn();
@@ -312,7 +313,8 @@ class InterestAdminControllerIntegrationTest extends BaseIntegrationTest {
             put("/interests/" + interestId + "/admin/edit")
                 .param("name", interestName)
                 .param("description", interestDescription)
-                .param("criteriaNames", criterion1))
+                .param("criteriaNames", criterion1)
+                .param("exclusive", "false"))
         .andExpect(view().name("error/page"))
         .andExpect(status().isNotFound())
         .andReturn();
@@ -336,7 +338,8 @@ class InterestAdminControllerIntegrationTest extends BaseIntegrationTest {
                 put("/interests/" + interestId + "/admin/edit")
                     .param("name", interestName)
                     .param("description", interestDescription)
-                    .param("criteriaNames", criterion1))
+                    .param("criteriaNames", criterion1)
+                    .param("exclusive", "false"))
             .andExpect(status().is3xxRedirection())
             .andReturn();
     String[] redirectUrl = res.getResponse().getRedirectedUrl().split("/");

--- a/src/test/java/it/rate/webapp/controllers/PlaceControllerIntegrationTest.java
+++ b/src/test/java/it/rate/webapp/controllers/PlaceControllerIntegrationTest.java
@@ -61,6 +61,8 @@ class PlaceControllerIntegrationTest extends BaseIntegrationTest {
     Long interestId = 1L;
     String name = "Test name";
     String description = "Test description";
+    Double latitude = 50.5;
+    Double longitude = 15.2;
 
     // Perform POST request to create a new place and expect redirection
     MvcResult res =
@@ -68,7 +70,9 @@ class PlaceControllerIntegrationTest extends BaseIntegrationTest {
             .perform(
                 post("/interests/" + interestId + "/places/new")
                     .param("name", name)
-                    .param("description", description))
+                    .param("description", description)
+                    .param("latitude", String.valueOf(latitude))
+                    .param("longitude", String.valueOf(longitude)))
             .andExpect(status().is3xxRedirection())
             .andReturn();
 

--- a/src/test/java/it/rate/webapp/services/CategoryServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/CategoryServiceTest.java
@@ -1,6 +1,7 @@
 package it.rate.webapp.services;
 
 import it.rate.webapp.BaseTest;
+import it.rate.webapp.config.Constraints;
 import it.rate.webapp.models.Category;
 import it.rate.webapp.repositories.CategoryRepository;
 import jakarta.validation.ConstraintViolationException;
@@ -22,7 +23,7 @@ class CategoryServiceTest extends BaseTest {
 
   @Test
   void findMaxLimitByIdIn_TooManyCategoriesThrowsException() {
-    int maxLimit = categoryService.getMaxCategories();
+    int maxLimit = Constraints.MAX_CATEGORIES_PER_INTEREST;
     Set<Long> categoryIds = new HashSet<>();
     for (int i = 0; i < maxLimit + 1; i++) {
       categoryIds.add((long) i + 1);

--- a/src/test/java/it/rate/webapp/services/CriterionServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/CriterionServiceTest.java
@@ -41,7 +41,7 @@ class CriterionServiceTest extends BaseTest {
 
     when(criterionRepository.findAllByInterest(any())).thenReturn(criteria);
 
-    criterionService.updateExisting(interest, newCriteriaNames);
+    criterionService.updateAll(interest, newCriteriaNames);
 
     verify(criterionRepository, times(2)).save(any());
     verify(criterionRepository, times(0)).delete(any());
@@ -53,7 +53,7 @@ class CriterionServiceTest extends BaseTest {
 
     when(criterionRepository.findAllByInterest(any())).thenReturn(criteria);
 
-    criterionService.updateExisting(interest, newCriteriaNames);
+    criterionService.updateAll(interest, newCriteriaNames);
 
     verify(criterionRepository, times(0)).save(any());
     verify(criterionRepository, times(1)).delete(any());
@@ -65,7 +65,7 @@ class CriterionServiceTest extends BaseTest {
 
     when(criterionRepository.findAllByInterest(any())).thenReturn(criteria);
 
-    criterionService.updateExisting(interest, newCriteriaNames);
+    criterionService.updateAll(interest, newCriteriaNames);
 
     verify(criterionRepository, times(1)).save(any());
     verify(criterionRepository, times(1)).delete(any());

--- a/src/test/java/it/rate/webapp/services/InterestServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/InterestServiceTest.java
@@ -29,7 +29,7 @@ class InterestServiceTest extends BaseTest {
             .id(1L)
             .username("Lojza")
             .email("lojza@lojza.cz")
-            .password("pass")
+            .password("Password1")
             .serverRole(ServerRole.USER)
             .build();
     Interest i1 = Interest.builder().id(1L).name("zTest").description("desc").build();

--- a/src/test/java/it/rate/webapp/services/LikeServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/LikeServiceTest.java
@@ -35,7 +35,7 @@ public class LikeServiceTest extends BaseTest {
             .id(1L)
             .username("Lojza")
             .email("lojza@lojza.cz")
-            .password("pass")
+            .password("Password1")
             .serverRole(ServerRole.USER)
             .build();
     i1 = Interest.builder().id(1L).name("Interest").description("Description").build();

--- a/src/test/java/it/rate/webapp/services/ManageInterestServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/ManageInterestServiceTest.java
@@ -30,9 +30,9 @@ class ManageInterestServiceTest extends BaseTest {
 
   @BeforeEach
   void setUp() {
-    u1 = AppUser.builder().username("Lojza").id(1L).password("password").email("l@l.com").build();
+    u1 = AppUser.builder().username("Lojza").id(1L).password("Password1").email("l@l.com").build();
 
-    i1 = Interest.builder().id(1L).name("IT").description("IT").exclusive(true).build();
+    i1 = Interest.builder().id(1L).name("IT kurzy").description("IT kurzy").exclusive(true).build();
 
     AppUser u2 = AppUser.builder().username("Alfonz").id(2L).build();
 

--- a/src/test/java/it/rate/webapp/services/PlaceServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/PlaceServiceTest.java
@@ -12,6 +12,7 @@ import it.rate.webapp.BaseTest;
 import it.rate.webapp.config.ServerRole;
 import it.rate.webapp.dtos.CriteriaOfPlaceDTO;
 import it.rate.webapp.dtos.CriterionAvgRatingDTO;
+import it.rate.webapp.dtos.PlaceInDTO;
 import it.rate.webapp.dtos.PlaceInfoDTO;
 import it.rate.webapp.exceptions.badrequest.BadRequestException;
 import it.rate.webapp.models.*;
@@ -85,8 +86,15 @@ class PlaceServiceTest extends BaseTest {
     // Mock the placeRepository to return whatever Place object it receives
     when(placeRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
+    PlaceInDTO placeDTO =
+        new PlaceInDTO(
+            p1.getName(),
+            p1.getAddress(),
+            p1.getDescription(),
+            p1.getLatitude(),
+            p1.getLongitude());
     // Call the method under test
-    Place res = placeService.save(p1, i1, u1);
+    Place res = placeService.save(placeDTO, i1, u1);
 
     // Assertions to verify the results
     assertSame(res.getCreator(), u1);
@@ -94,7 +102,7 @@ class PlaceServiceTest extends BaseTest {
 
     // Verify that placeRepository.save() was called exactly once with the same Place object used in
     // the test
-    verify(placeRepository, times(1)).save(same(p1));
+    verify(placeRepository, times(1)).save(same(res));
   }
 
   @Test

--- a/src/test/java/it/rate/webapp/services/PlaceServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/PlaceServiceTest.java
@@ -58,7 +58,7 @@ class PlaceServiceTest extends BaseTest {
             .id(1L)
             .username("Lojza")
             .email("lojza@lojza.cz")
-            .password("pass")
+            .password("Password1")
             .serverRole(ServerRole.USER)
             .build();
     u2 =
@@ -66,7 +66,7 @@ class PlaceServiceTest extends BaseTest {
             .id(2L)
             .username("Franta")
             .email("franta@franta.cz")
-            .password("pass")
+            .password("Password1")
             .serverRole(ServerRole.USER)
             .build();
     i1 = Interest.builder().id(1L).name("Interest").description("Description").build();

--- a/src/test/java/it/rate/webapp/services/RatingServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/RatingServiceTest.java
@@ -41,7 +41,7 @@ class RatingServiceTest extends BaseTest {
             .id(1L)
             .username("Lojza")
             .email("lojza@lojza.cz")
-            .password("pass")
+            .password("Password1")
             .serverRole(ServerRole.USER)
             .build();
 

--- a/src/test/java/it/rate/webapp/services/RoleServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/RoleServiceTest.java
@@ -36,12 +36,12 @@ class RoleServiceTest extends BaseTest {
         AppUser.builder()
             .username("Lojza")
             .id(1L)
-            .password("password")
+            .password("Password1")
             .email("l@l.com")
             .serverRole(ServerRole.USER)
             .build();
 
-    i1 = Interest.builder().id(1L).name("IT").description("IT").exclusive(true).build();
+    i1 = Interest.builder().id(1L).name("IT kurzy").description("IT kurzy").exclusive(true).build();
 
     Role r1 = new Role(u1, i1, Role.RoleType.VOTER);
 

--- a/src/test/java/it/rate/webapp/services/UserServiceTest.java
+++ b/src/test/java/it/rate/webapp/services/UserServiceTest.java
@@ -35,7 +35,7 @@ class UserServiceTest extends BaseTest {
 
   @Test
   void registerUserEmailExists() {
-    SignupUserInDTO user = new SignupUserInDTO("a@b.c", "Password123", "u");
+    SignupUserInDTO user = new SignupUserInDTO("a@b.c", "Password123", "username");
     when(userRepository.existsByEmailIgnoreCase(any())).thenReturn(true);
     when(userRepository.existsByUsernameIgnoreCase(any())).thenReturn(false);
     assertThrows(UserAlreadyExistsException.class, () -> userService.registerUser(user));
@@ -43,7 +43,7 @@ class UserServiceTest extends BaseTest {
 
   @Test
   void registerUserUsernameExists() {
-    SignupUserInDTO user = new SignupUserInDTO("a@b.c", "Password123", "u");
+    SignupUserInDTO user = new SignupUserInDTO("a@b.c", "Password123", "username");
     when(userRepository.existsByEmailIgnoreCase(any())).thenReturn(false);
     when(userRepository.existsByUsernameIgnoreCase(any())).thenReturn(true);
     assertThrows(UserAlreadyExistsException.class, () -> userService.registerUser(user));
@@ -51,7 +51,7 @@ class UserServiceTest extends BaseTest {
 
   @Test
   void registerUserValid() throws BadRequestException {
-    SignupUserInDTO user = new SignupUserInDTO("a@b.c", "Password123", "u");
+    SignupUserInDTO user = new SignupUserInDTO("a@b.c", "Password123", "username");
     when(userRepository.existsByEmailIgnoreCase(any())).thenReturn(false);
     when(userRepository.existsByUsernameIgnoreCase(any())).thenReturn(false);
     userService.registerUser(user);


### PR DESCRIPTION
# RIB-159: Fix Database settings for long descriptions
### Once deployed, this should effectively fix production site breaks when creating/editing interests and places no matter the user input.

- Length constraints introduced on inputs to prevent crashing with inputs longer than db datatype capacity
- Due to field validation where Entity ID doesnt exist yet (create new), DTOs are now being used across the app as method parameters instead of actual entity.
- Description fields now show remaining available characters