### PR TITLE
RIB-168: favicon possibly fixed

### DIFF
--- a/src/main/resources/static/icons/favicon/site.webmanifest
+++ b/src/main/resources/static/icons/favicon/site.webmanifest
@@ -3,7 +3,7 @@
     "short_name": "",
     "icons": [
         {
-            "src": "/android-chrome-144x144.png",
+            "src": "/icons/favicon/android-chrome-144x144.png",
             "sizes": "144x144",
             "type": "image/png"
         }


### PR DESCRIPTION
I was not able to reproduce the bug, but I think this was causing it as it is the only reference to the android favicon

![image](https://github.com/MatejFrnka/rate-it/assets/36565043/545fa090-eb8d-4432-985e-14591ecd6ffd)
