### PR TITLE
RIB-178: Add token validity, token exp info on reset submission

### DIFF
--- a/src/main/java/it/rate/webapp/exceptions/badrequest/PasswordMismatchException.java
+++ b/src/main/java/it/rate/webapp/exceptions/badrequest/PasswordMismatchException.java
@@ -1,0 +1,15 @@
+package it.rate.webapp.exceptions.badrequest;
+
+public class PasswordMismatchException extends BadRequestException {
+  public PasswordMismatchException(String message) {
+    super(message);
+  }
+
+  public PasswordMismatchException() {
+    super("Passwords do not match. Please try again.");
+  }
+
+  public PasswordMismatchException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/src/main/java/it/rate/webapp/models/PasswordReset.java
+++ b/src/main/java/it/rate/webapp/models/PasswordReset.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Setter
@@ -19,8 +21,29 @@ public class PasswordReset {
 
   @OneToOne private AppUser user;
 
+  private static final int EXPIRATION_MINUTES = 60;
+  private LocalDateTime expiration;
+
   public PasswordReset(AppUser user, String token) {
     this.user = user;
     this.token = token;
+    this.expiration  = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES);
+  }
+
+  public void updateToken(String token) {
+    this.token = token;
+    this.expiration = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES);
+  }
+
+  public static String getFormattedExpiration() {
+    StringBuilder sb = new StringBuilder();
+    int hours = EXPIRATION_MINUTES / 60;
+    int minutes = EXPIRATION_MINUTES % 60;
+    sb.append(hours > 0 ? hours + " hour" : "").append(hours > 1 ? "s" : "");
+    if (hours > 0 && minutes > 0) {
+      sb.append(" and ");
+    }
+    sb.append(minutes > 0 ? minutes + " minute" : "").append(minutes > 1 ? "s" : "");
+    return sb.toString();
   }
 }

--- a/src/main/resources/db/migration/V4_08_02_2308__add_pwreset_expiry.sql
+++ b/src/main/resources/db/migration/V4_08_02_2308__add_pwreset_expiry.sql
@@ -1,0 +1,2 @@
+ALTER TABLE password_reset
+    ADD expiration TIMESTAMP WITHOUT TIME ZONE;

--- a/src/main/resources/templates/user/loginForm.html
+++ b/src/main/resources/templates/user/loginForm.html
@@ -30,6 +30,7 @@
                 </section>
                 <a th:href="@{/reset}" class="forgot-password">Forgot password?</a>
                 <p th:if="${param.error}" class="error">Invalid username or password</p>
+                <p th:if="${resetSuccess}" style="margin: auto" class="successful" th:text="${resetSuccess}"></p>
                 <div class="user-form-button">
                     <button type="submit" class="sign-button">Login</button>
                 </div>

--- a/src/main/resources/templates/user/resetPassword.html
+++ b/src/main/resources/templates/user/resetPassword.html
@@ -21,6 +21,7 @@
                            placeholder="Enter your email address…" required>
                     <img class="user-icon" src="/icons/email-icon.png" alt="email-icon">
                 </section>
+                <p th:if="${error}" th:text="${error}" class="error"></p>
                 <div class="user-form-button">
                     <button type="submit" class="sign-button">Reset</button>
                 </div>

--- a/src/main/resources/templates/user/resetSubmitted.html
+++ b/src/main/resources/templates/user/resetSubmitted.html
@@ -12,6 +12,7 @@
             <img src="/icons/R-logo.png" alt="Logo">
         </div>
         <p th:text="'Your request was submitted. If the email address ' + ${email} + ' is correct, you should receive an email shortly with further instructions.'"></p>
+        <p th:text="'The reset token is valid for ' + ${tokenExpiry} + '.'"></p>
         <p>If the email hasn't arrived within next few minutes, please check your spam folder or try again.</p>
         <div class="row col-7" id="error-homepage-button">
             <a class="button" th:href="@{/}">Go to Homepage</a>


### PR DESCRIPTION
## Password reset token validity

- Reset token now has limited time validity
- Validity set as constant in PasswordReset entity in minutes format (currently set to 60 = 1 hour)
- After password reset submission, user receives information about token expiration in human readable format.
- Added success feedback message on successful password reset